### PR TITLE
fix(release): add required crates.io metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 version = "0.1.3"
+repository = "https://github.com/yohei1126/immutable-trace"
 
 [workspace.dependencies]
 blake3 = "1.5"

--- a/crates/audit-cli/Cargo.toml
+++ b/crates/audit-cli/Cargo.toml
@@ -3,6 +3,8 @@ name = "audit-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+description = "CLI for signing records and verifying immutable trace integrity"
 
 [dependencies]
 clap.workspace = true

--- a/crates/device-agent/Cargo.toml
+++ b/crates/device-agent/Cargo.toml
@@ -3,6 +3,8 @@ name = "device-agent"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+description = "Device-side helpers to build and sign immutable trace records"
 
 [dependencies]
 ledger-core.workspace = true

--- a/crates/ingest-api/Cargo.toml
+++ b/crates/ingest-api/Cargo.toml
@@ -3,6 +3,8 @@ name = "ingest-api"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+description = "Ingestion and verification service logic for immutable trace records"
 
 [features]
 default = []

--- a/crates/ledger-core/Cargo.toml
+++ b/crates/ledger-core/Cargo.toml
@@ -3,6 +3,8 @@ name = "ledger-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+repository.workspace = true
+description = "Core data model, hashing, and signature verification primitives for immutable trace records"
 
 [dependencies]
 blake3.workspace = true


### PR DESCRIPTION
## Summary
- add `repository` in workspace package metadata
- add crate `description` fields required by crates.io publish

## Why
Release is currently failing in publish step with:
`missing or empty metadata fields: description`

## Scope
This PR only contains publish metadata fixes for crates.io.
