### PR TITLE
test: fill coverage gaps identified in #34

### DIFF
--- a/crates/edgesentry-rs/src/lib.rs
+++ b/crates/edgesentry-rs/src/lib.rs
@@ -206,6 +206,38 @@ mod tests {
     }
 
     #[test]
+    fn parse_fixed_hex_rejects_invalid_hex_chars() {
+        let invalid = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"; // 64 chars but not valid hex
+        let err = parse_fixed_hex::<32>(invalid).unwrap_err();
+        assert!(matches!(err, CliError::InvalidHex(_)), "expected InvalidHex, got: {err:?}");
+    }
+
+    #[test]
+    fn verify_record_returns_false_for_wrong_public_key() {
+        let private_key_hex = "0202020202020202020202020202020202020202020202020202020202020202";
+        let wrong_key_hex   = "0303030303030303030303030303030303030303030303030303030303030303";
+
+        let wrong_signing_key = SigningKey::from_bytes(
+            &parse_fixed_hex::<32>(wrong_key_hex).unwrap()
+        );
+        let wrong_public_key_hex = hex::encode(wrong_signing_key.verifying_key().to_bytes());
+
+        let record = sign_record(
+            "lift-01".to_string(),
+            1,
+            1_700_000_000_000,
+            b"temperature=40".to_vec(),
+            AuditRecord::zero_hash(),
+            "s3://bucket/lift-01/1.bin".to_string(),
+            private_key_hex,
+        )
+        .expect("record should be signed");
+
+        let valid = verify_record(&record, &wrong_public_key_hex).expect("verify should run");
+        assert!(!valid, "wrong public key must not verify the signature");
+    }
+
+    #[test]
     fn tampered_lift_demo_chain_is_detected() {
         let private_key_hex = "0101010101010101010101010101010101010101010101010101010101010101";
         let mut records = build_lift_inspection_demo_records(

--- a/crates/edgesentry-rs/tests/core_tests.rs
+++ b/crates/edgesentry-rs/tests/core_tests.rs
@@ -73,3 +73,32 @@ fn chain_verification_detects_invalid_sequence() {
         })
     );
 }
+
+#[test]
+fn chain_verification_accepts_empty_slice() {
+    assert!(verify_chain(&[]).is_ok());
+}
+
+#[test]
+fn chain_verification_accepts_single_valid_record() {
+    let record = dummy_record(1, AuditRecord::zero_hash());
+    assert!(verify_chain(&[record]).is_ok());
+}
+
+#[test]
+fn chain_verification_rejects_first_record_with_nonzero_prev_hash() {
+    let bad_first = dummy_record(1, [1u8; 32]);
+    let result = verify_chain(&[bad_first]);
+    assert_eq!(result, Err(ChainError::InvalidPrevHash { index: 0 }));
+}
+
+#[test]
+fn verify_payload_signature_rejects_wrong_key() {
+    let signing_key = SigningKey::from_bytes(&[8u8; 32]);
+    let wrong_key = VerifyingKey::from(&SigningKey::from_bytes(&[9u8; 32]));
+
+    let payload_hash = compute_payload_hash(b"lift-data");
+    let sig = sign_payload_hash(&signing_key, &payload_hash);
+
+    assert!(!verify_payload_signature(&wrong_key, &payload_hash, &sig));
+}

--- a/crates/edgesentry-rs/tests/storage_tests.rs
+++ b/crates/edgesentry-rs/tests/storage_tests.rs
@@ -505,3 +505,83 @@ fn accepts_ingest_without_cert_identity() {
 
     assert_eq!(service.audit_ledger().records().len(), 1);
 }
+
+#[test]
+fn rejects_unknown_device_and_logs_rejection() {
+    let signing_key = SigningKey::from_bytes(&[99u8; 32]);
+
+    let mut service = IngestService::new(
+        IntegrityPolicyGate::default(),
+        InMemoryRawDataStore::default(),
+        InMemoryAuditLedger::default(),
+        InMemoryOperationLog::default(),
+    );
+    // intentionally do NOT register any device
+
+    let payload = b"door-open";
+    let record = build_signed_record(
+        "lift-99",
+        1,
+        1,
+        payload,
+        AuditRecord::zero_hash(),
+        "s3://bucket/lift-99/1.bin",
+        &signing_key,
+    );
+
+    let err = service
+        .ingest(record, payload, None)
+        .expect_err("unknown device must be rejected");
+    assert!(
+        matches!(err, IngestServiceError::Verify(IngestError::UnknownDevice(ref id)) if id == "lift-99"),
+        "expected UnknownDevice, got: {err}"
+    );
+
+    assert!(service.audit_ledger().records().is_empty());
+    let logs = service.operation_log().entries();
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].decision, IngestDecision::Rejected);
+    assert_eq!(logs[0].device_id, "lift-99");
+}
+
+#[test]
+fn accepts_multi_record_sequential_ingest() {
+    let signing_key = SigningKey::from_bytes(&[101u8; 32]);
+    let verifying_key = VerifyingKey::from(&signing_key);
+
+    let mut service = IngestService::new(
+        IntegrityPolicyGate::default(),
+        InMemoryRawDataStore::default(),
+        InMemoryAuditLedger::default(),
+        InMemoryOperationLog::default(),
+    );
+    service.register_device("lift-01", verifying_key);
+
+    let payloads: &[&[u8]] = &[b"door-open", b"vibration-ok", b"brake-ok"];
+    let mut prev_hash = AuditRecord::zero_hash();
+
+    for (i, payload) in payloads.iter().enumerate() {
+        let seq = (i as u64) + 1;
+        let record = build_signed_record(
+            "lift-01",
+            seq,
+            seq,
+            payload,
+            prev_hash,
+            format!("s3://bucket/lift-01/{seq}.bin"),
+            &signing_key,
+        );
+        prev_hash = record.hash();
+        service.ingest(record, payload, None).expect("sequential ingest must succeed");
+    }
+
+    let records = service.audit_ledger().records();
+    assert_eq!(records.len(), 3);
+    assert_eq!(records[0].sequence, 1);
+    assert_eq!(records[1].sequence, 2);
+    assert_eq!(records[2].sequence, 3);
+
+    let logs = service.operation_log().entries();
+    assert_eq!(logs.len(), 3);
+    assert!(logs.iter().all(|e| e.decision == IngestDecision::Accepted));
+}

--- a/crates/edgesentry-rs/tests/verify_tests.rs
+++ b/crates/edgesentry-rs/tests/verify_tests.rs
@@ -148,6 +148,84 @@ fn rejects_out_of_order_sequence() {
 }
 
 #[test]
+fn rejects_unknown_device() {
+    let signing_key = SigningKey::from_bytes(&[55u8; 32]);
+
+    let mut state = IngestState::default();
+    // intentionally do NOT register any device
+
+    let r1 = build_signed_record(
+        "lift-99",
+        1,
+        1,
+        b"payload-1",
+        AuditRecord::zero_hash(),
+        "s3://bucket/r1.bin",
+        &signing_key,
+    );
+
+    let err = state.verify_and_accept(&r1).unwrap_err();
+    assert_eq!(err, IngestError::UnknownDevice("lift-99".to_string()));
+}
+
+#[test]
+fn two_devices_are_isolated() {
+    let sk_a = SigningKey::from_bytes(&[57u8; 32]);
+    let sk_b = SigningKey::from_bytes(&[59u8; 32]);
+    let vk_a = VerifyingKey::from(&sk_a);
+    let vk_b = VerifyingKey::from(&sk_b);
+
+    let mut state = IngestState::default();
+    state.register_device("lift-01", vk_a);
+    state.register_device("lift-02", vk_b);
+
+    let a1 = build_signed_record(
+        "lift-01",
+        1,
+        1,
+        b"payload-a1",
+        AuditRecord::zero_hash(),
+        "s3://bucket/a1.bin",
+        &sk_a,
+    );
+    let b1 = build_signed_record(
+        "lift-02",
+        1,
+        1,
+        b"payload-b1",
+        AuditRecord::zero_hash(),
+        "s3://bucket/b1.bin",
+        &sk_b,
+    );
+
+    assert!(state.verify_and_accept(&a1).is_ok());
+    assert!(state.verify_and_accept(&b1).is_ok());
+
+    // Each device's sequence advances independently
+    let a2 = build_signed_record(
+        "lift-01",
+        2,
+        2,
+        b"payload-a2",
+        a1.hash(),
+        "s3://bucket/a2.bin",
+        &sk_a,
+    );
+    let b2 = build_signed_record(
+        "lift-02",
+        2,
+        2,
+        b"payload-b2",
+        b1.hash(),
+        "s3://bucket/b2.bin",
+        &sk_b,
+    );
+
+    assert!(state.verify_and_accept(&a2).is_ok());
+    assert!(state.verify_and_accept(&b2).is_ok());
+}
+
+#[test]
 fn rejects_tampered_signature() {
     let signing_key = SigningKey::from_bytes(&[51u8; 32]);
     let verifying_key = VerifyingKey::from(&signing_key);


### PR DESCRIPTION
## Summary

Closes #34.

Adds 10 tests covering every untested code path identified in the coverage gap analysis.

## Changes

| Test | File | Gap # |
|---|---|---|
| `rejects_unknown_device` | `verify_tests.rs` | #1 |
| `chain_verification_accepts_empty_slice` | `core_tests.rs` | #2 |
| `chain_verification_accepts_single_valid_record` | `core_tests.rs` | #3 |
| `chain_verification_rejects_first_record_with_nonzero_prev_hash` | `core_tests.rs` | #4 |
| `two_devices_are_isolated` | `verify_tests.rs` | #5 |
| `verify_payload_signature_rejects_wrong_key` | `core_tests.rs` | #6 |
| `accepts_multi_record_sequential_ingest` | `storage_tests.rs` | #7 |
| `rejects_unknown_device_and_logs_rejection` | `storage_tests.rs` | #8 |
| `parse_fixed_hex_rejects_invalid_hex_chars` | `src/lib.rs` | #9 |
| `verify_record_returns_false_for_wrong_public_key` | `src/lib.rs` | #10 |

No production code changes — tests only.

## Test plan

- [x] `cargo test --workspace` — 34/34 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)