### PR TITLE
fix(ci): replace third-party actions with GitHub-native equivalents

### DIFF
--- a/.github/workflows/auto-version-tag.yml
+++ b/.github/workflows/auto-version-tag.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup update stable && rustup default stable
 
       - name: Prepare git metadata
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
   build_and_test:
     name: Build and Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -28,10 +30,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup update stable && rustup default stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Build (release)
         run: cargo build --workspace --release
@@ -45,16 +56,27 @@ jobs:
   license_check:
     name: OSS License Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup update stable && rustup default stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked
@@ -66,16 +88,27 @@ jobs:
     name: Release Readiness (dry-run)
     runs-on: ubuntu-latest
     needs: [build_and_test, license_check]
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup update stable && rustup default stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Publish dry-run (edgesentry-rs)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,27 @@ jobs:
   quality_gate:
     name: Quality Gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup update stable && rustup default stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Build (release)
         run: cargo build --workspace --release --locked
@@ -41,16 +52,27 @@ jobs:
     name: Publish crates.io packages
     runs-on: ubuntu-latest
     needs: quality_gate
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup update stable && rustup default stable
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
 
       - name: Login crates.io
         env:
@@ -111,12 +133,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust (target)
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+        run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}
 
       - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@v2
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.target }}-cargo-
 
       - name: Build eds release binary
         run: cargo build --release --locked -p edgesentry-rs --target ${{ matrix.target }}
@@ -154,6 +183,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish_crates, build_cli_binaries]
     if: ${{ needs.publish_crates.result == 'success' && needs.build_cli_binaries.result == 'success' }}
+    permissions:
+      contents: write
 
     steps:
       - name: Download all build artifacts
@@ -162,8 +193,11 @@ jobs:
           path: dist
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            dist/**/*.tar.gz
-            dist/**/*.zip
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            dist/**/*.tar.gz dist/**/*.zip


### PR DESCRIPTION
## Summary

Fixes the `dtolnay/rust-toolchain`, `Swatinem/rust-cache`, and `softprops/action-gh-release` action policy violation that caused the Auto Version Tag pipeline to fail.

- Replace `dtolnay/rust-toolchain@stable` → `rustup update stable && rustup default stable` (runners ship with rustup pre-installed)
- Replace `Swatinem/rust-cache@v2` → `actions/cache@v4` (GitHub-owned) with standard Cargo cache paths
- Replace `softprops/action-gh-release@v2` → `gh release create` CLI call
- Add explicit `permissions: contents: read` to all jobs (resolves CodeQL alerts #2, #3, #6 / issue #40)
- `publish_github_release` job retains `contents: write` (needed to create a GitHub Release)

## Affected workflows

| File | Actions replaced |
|---|---|
| `ci.yml` | `dtolnay/rust-toolchain`, `Swatinem/rust-cache` (×3 jobs) |
| `auto-version-tag.yml` | `dtolnay/rust-toolchain` |
| `release.yml` | `dtolnay/rust-toolchain`, `Swatinem/rust-cache` (×3 jobs), `softprops/action-gh-release` |

## Test plan

- [ ] CI workflow passes on this PR (build, test, license check, clippy, dry-run publish)
- [ ] Auto Version Tag workflow runs successfully on main after merge
- [ ] No third-party `uses:` references remain (verified with `grep`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)