### PR TITLE
fix(release): checkout tag ref in downstream jobs; fix version parsing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create_tag.outputs.tag_name }}
 
       - name: Setup Rust
         run: rustup update stable && rustup default stable
@@ -65,6 +67,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create_tag.outputs.tag_name }}
 
       - name: Setup Rust
         run: rustup update stable && rustup default stable
@@ -96,7 +100,7 @@ jobs:
         run: |
           publish_if_missing() {
             crate="$1"
-            version="$(cargo pkgid -p "$crate" | cut -d'#' -f2)"
+            version="$(cargo metadata --no-deps --format-version 1 | python3 -c "import json,sys; data=json.load(sys.stdin); print(next(p['version'] for p in data['packages'] if p['name']=='$crate'))")"
             url="https://crates.io/api/v1/crates/${crate}/${version}"
 
             if curl --silent --show-error --fail "$url" >/dev/null 2>&1; then
@@ -134,6 +138,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create_tag.outputs.tag_name }}
 
       - name: Setup Rust (target)
         run: rustup update stable && rustup default stable && rustup target add ${{ matrix.target }}


### PR DESCRIPTION
## Problem

After `create_tag` bumps `Cargo.toml` and pushes a `chore(release): vX.Y.Z` commit, the downstream jobs (`quality_gate`, `publish_crates`, `build_cli_binaries`) were checking out the SHA that *triggered* the workflow — the pre-bump commit. This caused:

1. `publish_crates` saw the old version (e.g. `0.1.0`) in `Cargo.toml`
2. `cargo pkgid | cut -d'#' -f2` is also broken in newer Cargo output format, returning an empty/wrong version string, making the crates.io existence check fail
3. `cargo publish` then tried to publish the old version and hit `already exists on crates.io index`

## Fix

- All jobs after `create_tag` now checkout `ref: ${{ needs.create_tag.outputs.tag_name }}` — the tagged commit with the updated `Cargo.toml`
- Replace `cargo pkgid | cut` with `cargo metadata --no-deps | python3` for reliable version extraction across all Cargo versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)