### PR TITLE
docs: set up GitHub Pages landing page with mdBook

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,40 @@
+name: Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        run: cargo install mdbook --locked
+      - name: Build docs
+        run: mdbook build docs/
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # edgesentry-rs
 
-This repository contains a tamper-evident audit log PoC built in Rust from IoT devices to cloud services.
+This repository contains a tamper-evident audit log system built in Rust from IoT devices to cloud services.
 
 ## Motivation
 
@@ -12,7 +12,7 @@ For public-infrastructure IoT deployments, Singapore's Cybersecurity Labelling S
 
 https://www.csa.gov.sg/our-programmes/certification-and-labelling-schemes/cybersecurity-labelling-scheme/about/
 
-Because those hardware-dependent setups are often difficult to evaluate quickly in an early PoC phase, this repository focuses on sample code for tamper prevention and tamper-evident audit records.
+Because those hardware-dependent setups are often difficult to evaluate quickly in an early evaluation phase, this repository focuses on sample code for tamper prevention and tamper-evident audit records.
 
 ## Package
 
@@ -24,7 +24,7 @@ For a glossary-style explanation of the core concepts in this repository, see [C
 
 ## Device Side vs Cloud Side
 
-This PoC assumes a public-infrastructure IoT deployment where field devices (for example, lift inspection devices) send inspection evidence to cloud services.
+This system assumes a public-infrastructure IoT deployment where field devices (for example, lift inspection devices) send inspection evidence to cloud services.
 
 ### Device side (resource-constrained edge)
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,10 @@
+[book]
+title = "edgesentry-rs"
+description = "Tamper-evident audit log PoC built in Rust from IoT devices to cloud services."
+authors = ["edgesentry-rs contributors"]
+language = "en"
+src = "src"
+
+[output.html]
+git-repository-url = "https://github.com/yohei1126/edgesentry-rs"
+edit-url-template = "https://github.com/yohei1126/edgesentry-rs/edit/main/docs/src/{path}"

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,7 @@
+# Summary
+
+[Introduction](introduction.md)
+
+- [Concepts](concepts.md)
+- [Quickstart](quickstart.md)
+- [CLI Reference](cli.md)

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -1,0 +1,9 @@
+# CLI Reference
+
+Full CLI usage, lift inspection scenario, and tampering walkthrough are in [AGENTS.md](https://github.com/yohei1126/edgesentry-rs/blob/main/AGENTS.md).
+
+Key sections:
+
+- **CLI Usage** — `sign-record`, `verify-record`, `verify-chain` commands with examples
+- **Lift Inspection Scenario (CLI End-to-End)** — generate a signed chain, verify it, tamper and confirm detection
+- **S3 / MinIO Switching** — `S3ObjectStoreConfig::for_aws_s3(...)` vs `S3ObjectStoreConfig::for_minio(...)`

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -1,0 +1,1 @@
+{{#include ../../CONCEPTS.md}}

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,1 @@
+{{#include ../../README.md}}

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,0 +1,10 @@
+# Quickstart
+
+Full setup instructions, prerequisites, and run commands are in [AGENTS.md](https://github.com/yohei1126/edgesentry-rs/blob/main/AGENTS.md).
+
+Key sections:
+
+- **Prerequisites (macOS)** — install Rust toolchain and `cargo-deny`
+- **Library example (no DB required)** — `cargo run -p edgesentry-rs --example lift_inspection_flow`
+- **Interactive local demo (PostgreSQL + MinIO)** — `bash scripts/local_demo.sh`
+- **Quality and license check** — `./scripts/run_unit_and_license_check.sh`


### PR DESCRIPTION
## Summary

Implements #44.

- Add `docs/book.toml` and `docs/src/` with `SUMMARY.md`, `introduction.md`, `concepts.md`, `quickstart.md`, and `cli.md`
- `introduction.md` and `concepts.md` use mdBook `{{#include}}` to pull from `README.md` and `CONCEPTS.md` directly — zero content duplication
- `quickstart.md` and `cli.md` are short reference pages linking to the relevant sections in `AGENTS.md`
- Add `.github/workflows/pages.yml` to build with `mdbook build docs/` and deploy via `actions/deploy-pages@v4` on push to `main`
- Remove "PoC" wording from `README.md`

## Setup required

Enable GitHub Pages in repo **Settings → Pages → Source: GitHub Actions** before the workflow can deploy.

## Test plan

- [ ] Merge and confirm the Pages workflow runs green
- [ ] Verify site is live at `https://yohei1126.github.io/edgesentry-rs/`
- [ ] Confirm `introduction` and `concepts` pages render `README.md` / `CONCEPTS.md` content without duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)