### PR TITLE
security: add explicit permissions to all CI workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,8 @@ on:
     types: [completed]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   integration:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,8 @@ jobs:
     name: Build eds (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     needs: [create_tag, quality_gate]
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Add `permissions: {}` at the workflow level in `ci.yml` and `integration.yml` to deny all token scopes by default, enforcing least privilege via per-job declarations
- Add `permissions: contents: read` to the `build_cli_binaries` job in `release.yml`, which previously inherited the top-level `contents: write` scope unnecessarily

## Changes

| Workflow | Change |
|----------|--------|
| `ci.yml` | Added top-level `permissions: {}` |
| `integration.yml` | Added top-level `permissions: {}` |
| `release.yml` | Added `permissions: contents: read` to `build_cli_binaries` job |

## Test plan

- [ ] CI pipeline passes on this PR
- [ ] Release workflow dry-run succeeds with the narrowed `build_cli_binaries` permissions

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)