### PR TITLE
security: add cargo-audit job to CI for CVE advisory checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,29 @@ jobs:
       - name: Check licenses (commercial-use policy)
         run: cargo deny check licenses
 
+  audit:
+    name: Security Audit (cargo-audit)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        run: rustup update stable && rustup default stable
+
+      - name: Install cargo-audit
+        run: cargo audit --version 2>/dev/null || cargo install cargo-audit --locked
+
+      - name: Run security audit
+        run: cargo audit
+
   release_readiness:
     name: Release Readiness (dry-run)
     runs-on: ubuntu-latest
-    needs: [build_and_test, license_check]
+    needs: [build_and_test, license_check, audit]
     permissions:
       contents: read
 


### PR DESCRIPTION
## Summary

- Add a `Security Audit (cargo-audit)` job to `ci.yml` that runs on every push and pull request
- `release_readiness` gate now depends on `audit` passing — a crate with a known CVE cannot be released

## Changes

- New `audit` job: installs `cargo-audit` and runs `cargo audit` against the RustSec advisory database
- `release_readiness` updated: `needs: [build_and_test, license_check, audit]`

## Test plan

- [ ] CI passes on this PR
- [ ] Verify the audit job appears in the Actions run

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)