### PR TITLE
fix: strip s3:// URI prefix before using object_ref as S3 key

### DIFF
--- a/crates/edgesentry-rs/src/ingest/storage.rs
+++ b/crates/edgesentry-rs/src/ingest/storage.rs
@@ -420,17 +420,34 @@ impl S3CompatibleRawDataStore {
 }
 
 #[cfg(feature = "s3")]
+impl S3CompatibleRawDataStore {
+    /// Extract the object key from an `object_ref` that may be a full `s3://bucket/key` URI
+    /// or a plain key path.  For example:
+    ///   `s3://bucket/lift-01/1.bin`  →  `lift-01/1.bin`
+    ///   `lift-01/1.bin`              →  `lift-01/1.bin`
+    fn object_key<'a>(&self, object_ref: &'a str) -> &'a str {
+        if let Some(rest) = object_ref.strip_prefix("s3://") {
+            if let Some(slash) = rest.find('/') {
+                return &rest[slash + 1..];
+            }
+        }
+        object_ref
+    }
+}
+
+#[cfg(feature = "s3")]
 impl RawDataStore for S3CompatibleRawDataStore {
     type Error = S3StoreError;
 
     fn put(&mut self, object_ref: &str, payload: &[u8]) -> Result<(), Self::Error> {
+        let key = self.object_key(object_ref);
         let stream = aws_sdk_s3::primitives::ByteStream::from(payload.to_vec());
         self.runtime
             .block_on(
                 self.client
                     .put_object()
                     .bucket(&self.bucket)
-                    .key(object_ref)
+                    .key(key)
                     .body(stream)
                     .send(),
             )

--- a/crates/edgesentry-rs/tests/s3_integration.rs
+++ b/crates/edgesentry-rs/tests/s3_integration.rs
@@ -28,6 +28,16 @@ mod s3_integration {
         Some((endpoint, access_key, secret_key, bucket))
     }
 
+    /// Strip a `s3://bucket/` URI prefix from an object reference, returning the bare key.
+    fn s3_key(object_ref: &str) -> &str {
+        if let Some(rest) = object_ref.strip_prefix("s3://") {
+            if let Some(slash) = rest.find('/') {
+                return &rest[slash + 1..];
+            }
+        }
+        object_ref
+    }
+
     /// Fetch an object from MinIO; returns `None` when the key does not exist.
     fn get_object(
         endpoint: &str,
@@ -36,6 +46,7 @@ mod s3_integration {
         bucket: &str,
         key: &str,
     ) -> Option<Vec<u8>> {
+        let key = s3_key(key);
         use aws_config::BehaviorVersion;
         use aws_config::Region;
         use aws_credential_types::Credentials;


### PR DESCRIPTION
## Summary

- `object_ref` values like `s3://bucket/lift-01/inspection-1.bin` were passed directly as MinIO keys, causing `s3 put failed: service error` in integration tests
- Added `S3CompatibleRawDataStore::object_key()` to strip the `s3://{bucket}/` scheme+bucket prefix, extracting the bare key path (`lift-01/inspection-1.bin`)
- Applied the same `s3_key()` extraction in the `get_object` test helper in `s3_integration.rs`

## Test plan

- [ ] `cargo test --workspace` — all tests pass
- [ ] Integration test step 6 (demo-ingest) accepts all 3 records instead of rejecting with service error

🤖 Generated with [Claude Code](https://claude.com/claude-code)