### PR TITLE
refactor: reorganize into identity and integrity modules (closes #52)

### DIFF
--- a/crates/edgesentry-rs/src/agent.rs
+++ b/crates/edgesentry-rs/src/agent.rs
@@ -1,6 +1,7 @@
 use ed25519_dalek::SigningKey;
 
-use crate::crypto::{compute_payload_hash, sign_payload_hash};
+use crate::identity::sign_payload_hash;
+use crate::integrity::compute_payload_hash;
 use crate::record::{AuditRecord, Hash32};
 
 pub fn build_signed_record(

--- a/crates/edgesentry-rs/src/identity.rs
+++ b/crates/edgesentry-rs/src/identity.rs
@@ -1,15 +1,19 @@
+//! Ed25519 device identity — signing and verification primitives.
+//!
+//! This module covers the cryptographic identity layer: signing a payload hash
+//! with a device private key and verifying the signature with the registered
+//! public key.  All key-generation helpers live in the crate root (`lib.rs`).
+
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 
 use crate::record::{Hash32, Signature64};
 
-pub fn compute_payload_hash(payload: &[u8]) -> Hash32 {
-    *blake3::hash(payload).as_bytes()
-}
-
+/// Sign a payload hash with the device's Ed25519 signing key.
 pub fn sign_payload_hash(signing_key: &SigningKey, payload_hash: &Hash32) -> Signature64 {
     signing_key.sign(payload_hash).to_bytes()
 }
 
+/// Verify that `signature` over `payload_hash` was produced by `verifying_key`.
 pub fn verify_payload_signature(
     verifying_key: &VerifyingKey,
     payload_hash: &Hash32,

--- a/crates/edgesentry-rs/src/ingest/storage.rs
+++ b/crates/edgesentry-rs/src/ingest/storage.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use thiserror::Error;
 
-use crate::crypto::compute_payload_hash;
+use crate::integrity::compute_payload_hash;
 use crate::record::AuditRecord;
 use super::policy::IntegrityPolicyGate;
 use super::verify::IngestError;

--- a/crates/edgesentry-rs/src/ingest/verify.rs
+++ b/crates/edgesentry-rs/src/ingest/verify.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use ed25519_dalek::VerifyingKey;
 use thiserror::Error;
 
-use crate::crypto::verify_payload_signature;
+use crate::identity::verify_payload_signature;
 use crate::record::{AuditRecord, Hash32};
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/crates/edgesentry-rs/src/integrity.rs
+++ b/crates/edgesentry-rs/src/integrity.rs
@@ -1,7 +1,19 @@
+//! BLAKE3 hash-chain integrity — payload hashing and chain verification.
+//!
+//! This module covers the tamper-detection layer: hashing a raw payload with
+//! BLAKE3 and verifying that a sequence of `AuditRecord`s forms an unbroken
+//! hash chain.
+
 use thiserror::Error;
 
 use crate::record::AuditRecord;
 
+/// Compute the BLAKE3 hash of a raw payload.
+pub fn compute_payload_hash(payload: &[u8]) -> [u8; 32] {
+    *blake3::hash(payload).as_bytes()
+}
+
+/// Errors produced by [`verify_chain`].
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum ChainError {
     #[error("invalid previous hash at index {index}")]
@@ -14,6 +26,12 @@ pub enum ChainError {
     },
 }
 
+/// Verify that `records` form a valid hash chain.
+///
+/// - The first record must have `prev_record_hash == [0u8; 32]`.
+/// - Each subsequent record's `prev_record_hash` must equal the hash of the
+///   preceding record.
+/// - Sequences must be strictly monotonically increasing by 1.
 pub fn verify_chain(records: &[AuditRecord]) -> Result<(), ChainError> {
     if records.is_empty() {
         return Ok(());

--- a/crates/edgesentry-rs/src/lib.rs
+++ b/crates/edgesentry-rs/src/lib.rs
@@ -1,12 +1,12 @@
 mod agent;
-mod chain;
-mod crypto;
+pub mod identity;
+pub mod integrity;
 pub mod ingest;
 mod record;
 
 pub use agent::build_signed_record;
-pub use chain::{verify_chain, ChainError};
-pub use crypto::{compute_payload_hash, sign_payload_hash, verify_payload_signature};
+pub use identity::{sign_payload_hash, verify_payload_signature};
+pub use integrity::{compute_payload_hash, verify_chain, ChainError};
 pub use ingest::{
     AuditLedger, InMemoryAuditLedger, InMemoryOperationLog, InMemoryRawDataStore, IngestDecision,
     IngestError, IngestService, IngestServiceError, IngestState, IntegrityPolicyGate,

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -26,10 +26,10 @@ Deliver a software reference implementation that satisfies Singapore CLS Level 3
 
 ### Milestone 1.1: Identity & Integrity Core
 
-These are planned module names — not yet separate crates. Currently, they are implemented together in `crates/edgesentry-rs`.
+These are modules within `crates/edgesentry-rs`, not yet separate crates.
 
-- `edgesentry-identity` *(planned)* — Ed25519 device signature implementation
-- `edgesentry-integrity` *(planned)* — BLAKE3 hash chain tamper-detection protocol
+- `edgesentry_rs::identity` — Ed25519 device signature implementation
+- `edgesentry_rs::integrity` — BLAKE3 hash chain tamper-detection protocol
 
 ### Milestone 1.2: The C/C++ Bridge
 


### PR DESCRIPTION
## Summary

Milestone 1.1 — splits the flat `crypto`/`chain` modules into two clearly scoped public modules within `crates/edgesentry-rs`:

| New module | Content | Replaces |
|---|---|---|
| `src/identity.rs` | Ed25519 signing & verification (`sign_payload_hash`, `verify_payload_signature`) | `src/crypto.rs` (partial) |
| `src/integrity.rs` | BLAKE3 hashing + hash-chain verification (`compute_payload_hash`, `verify_chain`, `ChainError`) | `src/crypto.rs` (partial) + `src/chain.rs` |

Both modules are now `pub`, making `edgesentry_rs::identity` and `edgesentry_rs::integrity` directly accessible to library consumers.

Internal callers updated: `agent.rs`, `ingest/storage.rs`, `ingest/verify.rs`.

The **public API is unchanged** — all previously re-exported symbols remain available from `edgesentry_rs` root.

## Test plan

- [ ] `cargo test --workspace` — all tests pass with zero changes to test code
- [ ] `cargo check -p edgesentry-rs --features s3,postgres` — compiles cleanly

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)