### PR TITLE
chore: revert version to 0.1.2 — 0.2.0 reserved for Phase 1 completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "edgesentry-bridge"
-version = "0.2.0"
+version = "0.1.2"
 dependencies = [
  "cbindgen",
  "ed25519-dalek",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "edgesentry-rs"
-version = "0.2.0"
+version = "0.1.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT OR Apache-2.0"
-version = "0.2.0"
+version = "0.1.2"
 repository = "https://github.com/yohei1126/edgesentry-rs"
 
 [workspace.dependencies]


### PR DESCRIPTION
The automated release pipeline bumped the workspace version to 0.2.0 and created the `v0.2.0` tag, but the quality gate failed before any release was published.

The `v0.2.0` tag has been deleted. This PR rolls the version back to `0.1.2` so the release pipeline will correctly bump to `0.2.0` when Phase 1 is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)