### PR TITLE
docs: software update publisher isolation and key management (closes #81)

### DIFF
--- a/docs/src/key_management.md
+++ b/docs/src/key_management.md
@@ -135,7 +135,77 @@ Rotate a device key when:
 
 ---
 
-## 6. HSM Path (CLS Level 4)
+## 6. Software Update Publisher Keys
+
+Software update verification uses a separate set of Ed25519 keys from device signing keys. A **publisher key** belongs to the entity that signs firmware or software packages; a **device signing key** belongs to the individual device that signs audit records. Never mix these roles.
+
+### 6.1 Key generation and storage
+
+Generate a publisher keypair the same way as a device keypair:
+
+```bash
+eds keygen --out publisher-acme-firmware.key.json
+```
+
+The **private key** must be kept in a high-security offline environment (HSM, air-gapped workstation, or a secrets manager with strict access control). It is used only at build time to sign a release artifact, never on the device itself.
+
+The **public key** is embedded in the device firmware image at manufacture time and loaded into `UpdateVerifier` at runtime:
+
+```rust
+use edgesentry_rs::update::UpdateVerifier;
+use ed25519_dalek::VerifyingKey;
+
+let public_key_bytes: [u8; 32] = /* bytes baked into firmware */;
+let verifying_key = VerifyingKey::from_bytes(&public_key_bytes)?;
+
+let mut verifier = UpdateVerifier::new();
+verifier.register_publisher("acme-firmware", verifying_key);
+```
+
+### 6.2 One publisher ID per key
+
+Register each key under a distinct `publisher_id`. Avoid registering the same key under multiple IDs or multiple keys under the same ID unless your threat model explicitly requires it.
+
+```rust
+// Correct: one key per publisher
+verifier.register_publisher("acme-firmware", firmware_key);
+verifier.register_publisher("acme-config",   config_key);
+
+// Avoid: same key shared across publishers — a signature from one
+// package type could be accepted for the other
+verifier.register_publisher("acme-firmware", shared_key); // ⚠
+verifier.register_publisher("acme-config",   shared_key); // ⚠
+```
+
+### 6.3 Key confusion attacks
+
+A **key confusion attack** occurs when a signature produced for one package type is submitted as a valid signature for another. `UpdateVerifier` prevents this because:
+
+1. The caller passes an explicit `publisher_id` to `verify()`.
+2. The verifier looks up the key registered under that exact ID.
+3. A signature by `acme-config`'s key will not verify under `acme-firmware`'s key.
+
+This only holds when each publisher has a unique key. If keys are shared across publishers (see §6.2), the isolation breaks.
+
+### 6.4 Publisher key rotation
+
+Rotate a publisher key when the private key may have been exposed or your security policy requires periodic rotation.
+
+1. Generate a new keypair offline.
+2. Sign the next firmware release with the new private key.
+3. Distribute a firmware update that embeds the new public key and calls `register_publisher` with the new key. Include both old and new keys during the transition window so devices on either firmware version can verify updates.
+4. After all devices have moved to the new firmware, remove the old key registration.
+5. Securely destroy the old private key.
+
+### 6.5 FFI (C/C++ devices)
+
+For devices integrating via the C/C++ FFI bridge, publisher key verification will be exposed as `eds_verify_update` (tracked in [#80](https://github.com/yohei1126/edgesentry-rs/issues/80)). Until that function is available, C/C++ devices must call into Rust via a thin wrapper or handle publisher verification at the application layer.
+
+The public key bytes to pass to `eds_verify_update` are the same 32-byte Ed25519 public key described above — provision them into the device at manufacture time, stored in a read-only flash region or secure element.
+
+---
+
+## 7. HSM Path (CLS Level 4)
 
 For CLS Level 4 and high-assurance deployments, private keys should never exist
 as extractable byte arrays. Instead, signing operations should be performed inside


### PR DESCRIPTION
## Summary

- Adds §6 **Software Update Publisher Keys** to `docs/src/key_management.md`
- Covers publisher key generation, secure storage, and provisioning at manufacture time
- Documents the one-publisher-per-key rule to prevent key confusion attacks
- Explains how `UpdateVerifier`'s `publisher_id` registry prevents cross-publisher signature misuse
- Includes publisher key rotation procedure
- Links to #80 for the planned `eds_verify_update` FFI function

## Test plan

- [ ] `docs/src/key_management.md` renders correctly in mdBook (`mdbook build docs/`)
- [ ] All code snippets use real API types (`UpdateVerifier`, `VerifyingKey`)
- [ ] Links to #80 and #54 resolve correctly

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)