### PR TITLE
feat(demo): clarify edge device / gateway / cloud roles; add NetworkPolicy (closes #78)

### DIFF
--- a/crates/edgesentry-rs/examples/lift_inspection_flow.rs
+++ b/crates/edgesentry-rs/examples/lift_inspection_flow.rs
@@ -1,13 +1,47 @@
+// Three-role model
+// ─────────────────────────────────────────────────────────────────────────────
+// EDGE DEVICE  — a sensor or actuator that signs inspection records.
+//                In production this runs on embedded hardware (microcontroller,
+//                single-board computer). It only needs `build_signed_record`.
+//
+// EDGE GATEWAY — optional middle tier (industrial PC, 5G gateway) that
+//                forwards signed records from the device to the cloud over
+//                HTTPS / MQTT. The gateway does NOT verify content; it only
+//                routes. This OSS core does not implement the transport layer.
+//
+// CLOUD BACKEND — receives records, enforces network policy, checks identity
+//                 and integrity, and persists accepted records to storage.
+//                 Runs `NetworkPolicy`, `IntegrityPolicyGate`, `IngestService`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+use std::net::IpAddr;
+
 use ed25519_dalek::SigningKey;
 use edgesentry_rs::{
     build_signed_record, AuditRecord, InMemoryAuditLedger, InMemoryOperationLog,
-    InMemoryRawDataStore, IngestService, IntegrityPolicyGate,
+    InMemoryRawDataStore, IngestService, IntegrityPolicyGate, NetworkPolicy,
 };
 
 fn main() {
+    // ── EDGE DEVICE ──────────────────────────────────────────────────────────
+    // The device holds a unique Ed25519 signing key. The private key never
+    // leaves the device; the matching public key is registered on the cloud.
+
     let device_id = "lift-01";
     let signing_key = SigningKey::from_bytes(&[1u8; 32]);
     let verifying_key = signing_key.verifying_key();
+
+    // Simulated source IP of the gateway that forwards this device's records.
+    let gateway_ip: IpAddr = "10.0.1.42".parse().unwrap();
+
+    // ── CLOUD BACKEND — setup ────────────────────────────────────────────────
+    // The cloud configures a NetworkPolicy (deny-by-default) and registers
+    // the device's public key before any records arrive.
+
+    let mut network_policy = NetworkPolicy::new();
+    network_policy
+        .allow_cidr("10.0.1.0/24")
+        .expect("valid CIDR");
 
     let mut service = IngestService::new(
         IntegrityPolicyGate::default(),
@@ -16,6 +50,10 @@ fn main() {
         InMemoryOperationLog::default(),
     );
     service.register_device(device_id, verifying_key);
+
+    // ── EDGE DEVICE — sign records ───────────────────────────────────────────
+    // For each physical inspection event the device builds a signed record,
+    // links it to the previous record's hash, and emits it toward the gateway.
 
     let payloads = [
         b"check=door,status=ok" as &[u8],
@@ -41,13 +79,28 @@ fn main() {
         records.push(record);
     }
 
+    // ── CLOUD BACKEND — ingest ───────────────────────────────────────────────
+    // For each record arriving from the gateway the cloud backend:
+    //   1. Checks the source IP against NetworkPolicy (CLS-06)
+    //   2. Passes the record to IngestService which runs IntegrityPolicyGate:
+    //      route identity → signature → sequence → hash-chain continuity
+
     for record in &records {
+        // Step 1: network gate — runs before any cryptographic check.
+        network_policy
+            .check(gateway_ip)
+            .expect("gateway IP should be allowed");
+
+        // Step 2: integrity gate + persistence.
         service
             .ingest(record.clone(), payloads[record.sequence as usize - 1], Some(device_id))
             .expect("ingest should succeed");
     }
 
     println!("Stored {} audit records", service.audit_ledger().records().len());
+
+    // ── CLOUD BACKEND — tamper rejection demo ────────────────────────────────
+    // A tampered record (payload hash flipped) must be rejected by the gate.
 
     let tampered_payload = b"tampered";
     let tampered_record = build_signed_record(
@@ -62,12 +115,19 @@ fn main() {
     let mut tampered = tampered_record;
     tampered.payload_hash[0] ^= 0x01;
 
+    // Network gate still passes (same gateway IP).
+    network_policy.check(gateway_ip).expect("gateway IP should be allowed");
+
+    // Integrity gate rejects the tampered record.
     let result = service.ingest(tampered, tampered_payload, Some(device_id));
     assert!(result.is_err(), "tampered record should be rejected");
     println!("Tampered record rejected: {:?}", result.unwrap_err());
 
     println!("Operation log entries: {}", service.operation_log().entries().len());
     for entry in service.operation_log().entries() {
-        println!("  {:?} device={} seq={} msg={}", entry.decision, entry.device_id, entry.sequence, entry.message);
+        println!(
+            "  {:?} device={} seq={} msg={}",
+            entry.decision, entry.device_id, entry.sequence, entry.message
+        );
     }
 }

--- a/docs/src/demo.md
+++ b/docs/src/demo.md
@@ -2,7 +2,19 @@
 
 Note: unlike the library-only example, this demo **requires** PostgreSQL and MinIO.
 
-This demo:
+## Three-role model
+
+EdgeSentry-RS is designed around three distinct roles. Understanding which role each step belongs to is key to reading the demo output correctly.
+
+| Role | Responsibility | In this demo |
+|------|---------------|-------------|
+| **Edge device** | Signs inspection records with an Ed25519 private key and emits them toward the cloud | Simulated by the `eds` CLI (`demo-lift-inspection`) |
+| **Edge gateway** | Forwards signed records from the device to the cloud over HTTPS / MQTT; does not verify content | Not implemented in this demo — in production this is an industrial PC or 5G gateway between the sensor and the cloud |
+| **Cloud backend** | Enforces `NetworkPolicy` (CLS-06), runs `IntegrityPolicyGate` (route identity → signature → sequence → hash-chain), and persists accepted records | PostgreSQL (audit ledger) + MinIO (raw payloads), driven by `demo-ingest` |
+
+The demo script labels each step with its role so you can see where the trust boundary is crossed.
+
+## What this demo does:
 
 - Starts PostgreSQL + MinIO backend services
 - Generates and verifies a signed chain with `eds`

--- a/scripts/local_demo.sh
+++ b/scripts/local_demo.sh
@@ -35,6 +35,17 @@ if ! command -v cargo >/dev/null 2>&1; then
   exit 1
 fi
 
+# Three-role model
+# ════════════════════════════════════════════════════════════════════════════
+# EDGE DEVICE   — lift-01 sensor (simulated by the eds CLI on this machine).
+#                 Signs inspection records with an Ed25519 private key.
+# EDGE GATEWAY  — not implemented in this demo; in production a gateway would
+#                 forward signed records from the device to the cloud over
+#                 HTTPS / MQTT.
+# CLOUD BACKEND — PostgreSQL (audit ledger) + MinIO (raw payload store).
+#                 Runs NetworkPolicy, IntegrityPolicyGate, and IngestService.
+# ════════════════════════════════════════════════════════════════════════════
+
 echo "[1/7] Starting PostgreSQL + MinIO..."
 docker compose -f "$COMPOSE_FILE" up -d postgres minio minio-setup >/dev/null
 echo "Backend started."
@@ -73,6 +84,9 @@ fi
 echo "MinIO setup: completed"
 wait_for_ok "3/7"
 
+echo "──────────────────────────────────────────────────────────────────────────"
+echo "EDGE DEVICE: generating and signing lift inspection records"
+echo "──────────────────────────────────────────────────────────────────────────"
 echo "[4/7] Generating demo lift inspection records + payloads..."
 (
   cd "$ROOT_DIR"
@@ -89,6 +103,9 @@ echo "CLI check: payloads generated -> $PAYLOADS_FILE"
 (cd "$ROOT_DIR" && cargo run -p edgesentry-rs -- verify-chain --records-file "$RECORDS_FILE")
 wait_for_ok "4/7"
 
+echo "──────────────────────────────────────────────────────────────────────────"
+echo "EDGE DEVICE (tamper simulation): flipping a bit to simulate data corruption"
+echo "──────────────────────────────────────────────────────────────────────────"
 echo "[4.5/7] Tampering the chain and verifying detection..."
 python3 - <<'PY'
 import json
@@ -114,6 +131,10 @@ fi
 echo "Tamper detection: PASSED (verify-chain exited with $TAMPER_EXIT_CODE)"
 wait_for_ok "4.5/7"
 
+echo "──────────────────────────────────────────────────────────────────────────"
+echo "CLOUD BACKEND: ingesting records through NetworkPolicy + IntegrityPolicyGate"
+echo "(in production, records arrive here from the edge gateway over HTTPS/MQTT)"
+echo "──────────────────────────────────────────────────────────────────────────"
 echo "[5/7] Ingesting records via IngestService (PostgreSQL + MinIO)..."
 (
   cd "$ROOT_DIR"
@@ -133,6 +154,9 @@ echo "[5/7] Ingesting records via IngestService (PostgreSQL + MinIO)..."
 )
 wait_for_ok "5/7"
 
+echo "──────────────────────────────────────────────────────────────────────────"
+echo "CLOUD BACKEND: querying persisted audit records and operation log"
+echo "──────────────────────────────────────────────────────────────────────────"
 echo "[6/7] Querying persisted data..."
 docker exec -i edgesentry-rs-postgres psql -U trace -d trace_audit \
   -c "SELECT id, device_id, sequence, object_ref, ingested_at FROM audit_records ORDER BY sequence;"


### PR DESCRIPTION
## Summary

- Adds three-role model (edge device / edge gateway / cloud backend) header comments to `examples/lift_inspection_flow.rs`
- Shows `NetworkPolicy::check` before every `IngestService::ingest` call so the full ingest gate is visible end-to-end
- Adds role-boundary banners (`EDGE DEVICE`, `CLOUD BACKEND`) to `scripts/local_demo.sh` at each step
- Adds a three-role model table and explanation to `docs/src/demo.md`

## Test plan

- [ ] `cargo run -p edgesentry-rs --example lift_inspection_flow` outputs 3 accepted + 1 rejected record
- [ ] `cargo test --workspace` passes
- [ ] `scripts/local_demo.sh` displays role banners at steps 4, 4.5, 5, and 6

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)