### PR TITLE
fix(ci): correct integration test target name and add consistency-check guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 All procedures are documented in [docs/src/](docs/src/) and apply equally to humans and AI agents.
 
+## Guidelines
+
+**After every change, verify consistency across code, tests, and docs.** See [Contributing — Consistency Check](docs/src/contributing.md#consistency-check) for the checklist.
+
 ## Quick Reference
 
 ### Understanding the system

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,5 +1,23 @@
 # Contributing
 
+## Consistency Check
+
+After every change — whether to code, tests, scripts, or docs — check that all three layers stay in sync:
+
+1. **Code → Docs**: If you add, remove, or rename a module, function, CLI command, or behavior, update all docs that reference it (`concepts.md`, `architecture.md`, `cli.md`, `quickstart.md`, `demo.md`, `traceability.md`).
+2. **Docs → Code**: If a doc describes a feature or command, verify it exists and works as described. Stale examples and wrong test target names cause CI failures.
+3. **Scripts → Code**: If you rename a test file or cargo feature, update every script and workflow that references it (e.g. `scripts/integration_test.sh`, `.github/workflows/`).
+4. **Traceability**: If you implement or change a compliance control, update the status in `docs/src/traceability.md` (✅ / ⚠️ / 🔲).
+
+A quick grep before opening a PR:
+
+```bash
+# Find docs that mention a symbol you changed
+grep -r "<old-name>" docs/ scripts/ .github/
+```
+
+---
+
 ## Issue Labels
 
 Every issue should carry one **type** label, one **priority** label, and one or more **category** labels.
@@ -100,7 +118,7 @@ TEST_S3_ENDPOINT=http://localhost:9000 \
 TEST_S3_ACCESS_KEY=minioadmin \
 TEST_S3_SECRET_KEY=minioadmin \
 TEST_S3_BUCKET=bucket \
-cargo test -p edgesentry-rs --features s3 --test s3_integration -- --nocapture
+cargo test -p edgesentry-rs --features s3 --test integration -- --nocapture
 ```
 
 Tests skip automatically when any of the four `TEST_S3_*` variables are unset.

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -117,7 +117,7 @@ echo "[8/8] Running Rust S3 integration tests..."
   TEST_S3_ACCESS_KEY="$MINIO_ACCESS_KEY" \
   TEST_S3_SECRET_KEY="$MINIO_SECRET_KEY" \
   TEST_S3_BUCKET="$MINIO_BUCKET" \
-  cargo test -p edgesentry-rs --features s3 --test s3_integration -- --nocapture
+  cargo test -p edgesentry-rs --features s3 --test integration -- --nocapture
 )
 
 echo ""


### PR DESCRIPTION
## Summary

- Fixes the integration test CI failure: `--test s3_integration` → `--test integration` (the actual test file is `tests/integration.rs`)
- Same fix applied to the example command in `docs/src/contributing.md`
- Adds the consistency-check guideline to `AGENTS.md` and `docs/src/contributing.md` (these commits were not included when #101 was closed)