### PR TITLE
chore: update all URLs from yohei1126 to edgesentry org

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 version = "0.1.2"
-repository = "https://github.com/yohei1126/edgesentry-rs"
+repository = "https://github.com/edgesentry/edgesentry-rs"
 
 [workspace.dependencies]
 blake3 = "1.5"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 An early-stage learning project building tamper-evident audit log infrastructure in Rust for IoT devices to cloud services. The license is commercially compatible (MIT/Apache 2.0); the implementation is actively in development and not yet production-ready.
 
-- **Repository:** [github.com/yohei1126/edgesentry-rs](https://github.com/yohei1126/edgesentry-rs)
-- **Documentation:** [yohei1126.github.io/edgesentry-rs](https://yohei1126.github.io/edgesentry-rs/)
+- **Repository:** [github.com/edgesentry/edgesentry-rs](https://github.com/edgesentry/edgesentry-rs)
+- **Documentation:** [edgesentry.github.io/edgesentry-rs](https://edgesentry.github.io/edgesentry-rs/)
 
 ## Documentation
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -6,5 +6,5 @@ language = "en"
 src = "src"
 
 [output.html]
-git-repository-url = "https://github.com/yohei1126/edgesentry-rs"
-edit-url-template = "https://github.com/yohei1126/edgesentry-rs/edit/main/docs/src/{path}"
+git-repository-url = "https://github.com/edgesentry/edgesentry-rs"
+edit-url-template = "https://github.com/edgesentry/edgesentry-rs/edit/main/docs/src/{path}"

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -136,7 +136,7 @@ SS 711:2025 and the IMDA IoT Cyber Security Guide require recorded STRIDE-based 
 | **D**enial of Service | Ingest endpoint | `NetworkPolicy` deny-by-default rejects unlisted sources before any crypto runs |
 | **E**levation of Privilege | Ingest gate | `IntegrityPolicyGate` verifies device registration and signature before accepting data |
 
-Producing the formal design artifact for CLS Level 3 assessment is tracked in [#93](https://github.com/yohei1126/edgesentry-rs/issues/93).
+Producing the formal design artifact for CLS Level 3 assessment is tracked in [#93](https://github.com/edgesentry/edgesentry-rs/issues/93).
 
 ## 14. SBOM (Software Bill of Materials)
 
@@ -144,4 +144,4 @@ A Software Bill of Materials lists all software components and their versions us
 
 For Rust projects, SBOM is generated from `Cargo.lock` using tools such as `cargo-sbom` or `cargo-cyclonedx`, producing a machine-readable inventory of all crates and their transitive dependencies.
 
-Generating and publishing the SBOM alongside the vendor disclosure checklist is tracked in [#92](https://github.com/yohei1126/edgesentry-rs/issues/92).
+Generating and publishing the SBOM alongside the vendor disclosure checklist is tracked in [#92](https://github.com/edgesentry/edgesentry-rs/issues/92).

--- a/docs/src/ffi_bridge.md
+++ b/docs/src/ffi_bridge.md
@@ -162,6 +162,6 @@ See the full example in
 ## HSM path
 
 For CLS Level 4, the private key should never exist as an extractable byte
-array.  The planned HSM integration ([#54](https://github.com/yohei1126/edgesentry-rs/issues/54))
+array.  The planned HSM integration ([#54](https://github.com/edgesentry/edgesentry-rs/issues/54))
 will delegate the `eds_sign_record` operation to an HSM-backed provider
 without exposing key bytes to the caller.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -2,8 +2,8 @@
 
 **"Paving the Way for a New Global Standard: Mathematically Provable Integrity at the Edge."**
 
-- **Repository:** [github.com/yohei1126/edgesentry-rs](https://github.com/yohei1126/edgesentry-rs)
-- **Documentation:** [yohei1126.github.io/edgesentry-rs](https://yohei1126.github.io/edgesentry-rs/)
+- **Repository:** [github.com/edgesentry/edgesentry-rs](https://github.com/edgesentry/edgesentry-rs)
+- **Documentation:** [edgesentry.github.io/edgesentry-rs](https://edgesentry.github.io/edgesentry-rs/)
 
 ## Why
 
@@ -43,7 +43,7 @@ Modeled after the "Simple, Portable, Fast" philosophy, EdgeSentry-RS implements 
 
 This project is licensed under either of:
 
-- [Apache License, Version 2.0](https://github.com/yohei1126/edgesentry-rs/blob/main/LICENSE-APACHE)
-- [MIT license](https://github.com/yohei1126/edgesentry-rs/blob/main/LICENSE-MIT)
+- [Apache License, Version 2.0](https://github.com/edgesentry/edgesentry-rs/blob/main/LICENSE-APACHE)
+- [MIT license](https://github.com/edgesentry/edgesentry-rs/blob/main/LICENSE-MIT)
 
 At your option.

--- a/docs/src/key_management.md
+++ b/docs/src/key_management.md
@@ -68,7 +68,7 @@ The private key must be kept secret on the device. Recommended practices:
 |-------------|---------------------|
 | Development / CI | Environment variable (`DEVICE_PRIVATE_KEY_HEX`) — never commit to version control |
 | Production (software) | Encrypted secrets store (e.g., HashiCorp Vault, AWS Secrets Manager, Azure Key Vault) |
-| Production (hardware) | Hardware Security Module (HSM) or Trusted Execution Environment (TEE) — see [#54](https://github.com/yohei1126/edgesentry-rs/issues/54) for the planned HSM path |
+| Production (hardware) | Hardware Security Module (HSM) or Trusted Execution Environment (TEE) — see [#54](https://github.com/edgesentry/edgesentry-rs/issues/54) for the planned HSM path |
 
 File-based storage (development only):
 
@@ -131,7 +131,7 @@ Rotate a device key when:
 5. Securely delete or revoke the old private key from all storage locations.
 
 > **Note:** Multi-key-per-device support (allowing old and new keys simultaneously
-> under the same `device_id`) is tracked in [#57](https://github.com/yohei1126/edgesentry-rs/issues/57).
+> under the same `device_id`) is tracked in [#57](https://github.com/edgesentry/edgesentry-rs/issues/57).
 
 ---
 
@@ -199,7 +199,7 @@ Rotate a publisher key when the private key may have been exposed or your securi
 
 ### 6.5 FFI (C/C++ devices)
 
-For devices integrating via the C/C++ FFI bridge, publisher key verification will be exposed as `eds_verify_update` (tracked in [#80](https://github.com/yohei1126/edgesentry-rs/issues/80)). Until that function is available, C/C++ devices must call into Rust via a thin wrapper or handle publisher verification at the application layer.
+For devices integrating via the C/C++ FFI bridge, publisher key verification will be exposed as `eds_verify_update` (tracked in [#80](https://github.com/edgesentry/edgesentry-rs/issues/80)). Until that function is available, C/C++ devices must call into Rust via a thin wrapper or handle publisher verification at the application layer.
 
 The public key bytes to pass to `eds_verify_update` are the same 32-byte Ed25519 public key described above — provision them into the device at manufacture time, stored in a read-only flash region or secure element.
 

--- a/docs/src/roadmap.md
+++ b/docs/src/roadmap.md
@@ -66,7 +66,7 @@ IMDA's IoT Cyber Security Guide requires a vendor disclosure checklist as CLS Le
 - Generate and publish SBOM (Software Bill of Materials) for all crates
 - Document vendor disclosure checklist responses for each category
 - Map checklist responses to existing implementation in the traceability matrix
-- See [#92](https://github.com/yohei1126/edgesentry-rs/issues/92)
+- See [#92](https://github.com/edgesentry/edgesentry-rs/issues/92)
 
 ### Milestone 1.5: STRIDE Threat Model + Binary Analysis Evidence 🔲 Planned
 
@@ -75,7 +75,7 @@ CLS Level 3 assessors expect recorded design artifacts, not just code. SS 711:20
 - STRIDE threat model covering: Spoofing (device identity), Tampering (audit records), Repudiation (operation logs), Information Disclosure (payload storage), Denial of Service (network policy), Elevation of Privilege (ingest gate)
 - Binary analysis report confirming no known CVEs in shipped crates (`cargo-audit`, `cargo-deny`)
 - Link threat model mitigations to traceability matrix entries
-- See [#93](https://github.com/yohei1126/edgesentry-rs/issues/93)
+- See [#93](https://github.com/edgesentry/edgesentry-rs/issues/93)
 
 ---
 
@@ -90,22 +90,22 @@ GCLI is the primary mechanism for Japan market entry without duplicate certifica
 - GCLI compliance pathway guide for Japan-based customers
 - CLS ↔ JC-STAR clause equivalence table
 - MRA fast-track guidance for customers holding Finnish, German, or Korean IoT certification
-- See [#94](https://github.com/yohei1126/edgesentry-rs/issues/94)
+- See [#94](https://github.com/edgesentry/edgesentry-rs/issues/94)
 
 ### Milestone 2.1: JC-STAR STAR-1/2 Alignment 🔲 Planned
 
 - Self-checklist and implementation guidance based on Japan's IoT Product Security Conformity Assessment criteria
-- See [#82](https://github.com/yohei1126/edgesentry-rs/issues/82)
+- See [#82](https://github.com/edgesentry/edgesentry-rs/issues/82)
 
 ### Milestone 2.2: Edge Intelligence 🔲 Planned
 
-- `edgesentry-summary` — data summarisation logic for high-performance Japanese sensors over bandwidth-constrained links. See [#83](https://github.com/yohei1126/edgesentry-rs/issues/83)
-- `edgesentry-detector` — local anomaly detection with signed audit evidence attached to results. See [#84](https://github.com/yohei1126/edgesentry-rs/issues/84)
+- `edgesentry-summary` — data summarisation logic for high-performance Japanese sensors over bandwidth-constrained links. See [#83](https://github.com/edgesentry/edgesentry-rs/issues/83)
+- `edgesentry-detector` — local anomaly detection with signed audit evidence attached to results. See [#84](https://github.com/edgesentry/edgesentry-rs/issues/84)
 
 ### Milestone 2.3: Cross-Border Education Program 🔲 Planned
 
 - Joint technical white paper to help Japanese companies bid on Singapore public-infrastructure projects
-- See [#85](https://github.com/yohei1126/edgesentry-rs/issues/85)
+- See [#85](https://github.com/edgesentry/edgesentry-rs/issues/85)
 
 ### Milestone 2.4: Cyber Trust Mark / ISO 27001 Organisational Track 🔲 Planned
 
@@ -113,7 +113,7 @@ Singapore's Cyber Trust Mark becomes mandatory for Critical Information Infrastr
 
 - Map EdgeSentry-RS implementation evidence to Cyber Trust Mark assessment categories
 - ISO 27001 control alignment documentation
-- See [#95](https://github.com/yohei1126/edgesentry-rs/issues/95)
+- See [#95](https://github.com/edgesentry/edgesentry-rs/issues/95)
 
 ### Milestone 2.5: CLS(MD) — Medical Device Variant 🔲 Planned
 
@@ -121,7 +121,7 @@ Singapore launched CLS for Medical Devices (CLS(MD)) in October 2024. If medical
 
 - CLS(MD) gap analysis against current implementation
 - Medical device–specific requirements identification
-- See [#96](https://github.com/yohei1126/edgesentry-rs/issues/96)
+- See [#96](https://github.com/edgesentry/edgesentry-rs/issues/96)
 
 ---
 
@@ -140,7 +140,7 @@ The UK Product Security and Telecommunications Infrastructure (PSTI) Act aligns 
 
 - Gap analysis between CLS Level 3 and UK PSTI requirements
 - PSTI compliance statement documentation
-- See [#97](https://github.com/yohei1126/edgesentry-rs/issues/97)
+- See [#97](https://github.com/edgesentry/edgesentry-rs/issues/97)
 
 ### Milestone 3.3: IEC 62443-4-2 + Hardware RoT 🔲 Planned
 
@@ -149,7 +149,7 @@ IEC 62443-4-2 governs component-level requirements for Critical Infrastructure (
 - IEC 62443-4-2 component requirement mapping
 - HSM integration via `edgesentry-bridge` for hardware-backed key storage (CLS Level 4)
 - RBAC/PAM design guidance for deployers
-- See [#54](https://github.com/yohei1126/edgesentry-rs/issues/54) and [#98](https://github.com/yohei1126/edgesentry-rs/issues/98)
+- See [#54](https://github.com/edgesentry/edgesentry-rs/issues/54) and [#98](https://github.com/edgesentry/edgesentry-rs/issues/98)
 
 ### Milestone 3.4: CCoP 2.0 / MTCS Tier 3 🔲 Planned
 
@@ -157,7 +157,7 @@ Singapore's Cybersecurity Code of Practice 2.0 (CCoP 2.0) is the operational com
 
 - CCoP 2.0 operational requirement mapping
 - MTCS Tier 3 applicability assessment for cloud deployment scenarios
-- See [#99](https://github.com/yohei1126/edgesentry-rs/issues/99)
+- See [#99](https://github.com/edgesentry/edgesentry-rs/issues/99)
 
 ### Milestone 3.5: Formal Verification & Hardening 🔲 Planned
 

--- a/docs/src/traceability.md
+++ b/docs/src/traceability.md
@@ -11,7 +11,7 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 | Principle | SS 711:2025 Requirement | Status |
 |-----------|------------------------|--------|
 | Secure by Default | Unique device identity, signed OTA updates | ✅ `identity.rs`, `update.rs` |
-| Rigour in Defence | STRIDE threat model, tamper detection | ⚠️ Hash chain ✅ — STRIDE artifact 🔲 [#93](https://github.com/yohei1126/edgesentry-rs/issues/93) |
+| Rigour in Defence | STRIDE threat model, tamper detection | ⚠️ Hash chain ✅ — STRIDE artifact 🔲 [#93](https://github.com/edgesentry/edgesentry-rs/issues/93) |
 | Accountability | Audit trail, operation logs, RBAC design | ✅ `ingest/` (AuditLedger, OperationLog) |
 | Resiliency | Deny-by-default networking, DoS protection | ✅ `ingest/network_policy.rs` |
 
@@ -38,7 +38,7 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 | JC-STAR | STAR-1 R4.1 |
 | Requirement | A published, actionable vulnerability reporting channel with defined SLAs |
 | Status | ⚠️ Partial |
-| Gap | Formal disclosure process not yet defined. See [#58](https://github.com/yohei1126/edgesentry-rs/issues/58) |
+| Gap | Formal disclosure process not yet defined. See [#58](https://github.com/edgesentry/edgesentry-rs/issues/58) |
 
 ---
 
@@ -49,7 +49,7 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 | JC-STAR | STAR-2 R2.2 |
 | Requirement | Software update packages must be signed and verified before installation |
 | Status | ✅ Implemented |
-| Implementation | `UpdateVerifier::verify` checks BLAKE3 payload hash then Ed25519 publisher signature before allowing installation; failed checks are logged as `UpdateVerifyDecision::Rejected` in `UpdateVerificationLog` ([`src/update.rs`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/update.rs)) |
+| Implementation | `UpdateVerifier::verify` checks BLAKE3 payload hash then Ed25519 publisher signature before allowing installation; failed checks are logged as `UpdateVerifyDecision::Rejected` in `UpdateVerificationLog` ([`src/update.rs`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/update.rs)) |
 | Tests | `tests/unit/update_tests.rs` — covers accepted path, tampered payload, invalid signature, unknown publisher, multi-publisher isolation |
 
 ---
@@ -61,11 +61,11 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 | JC-STAR | STAR-1 R1.2 |
 | Requirement | Private keys must be stored securely; a key registration process must exist |
 | Status | ✅ Implemented |
-| Implementation | Public key registry: `IntegrityPolicyGate::register_device` ([`src/ingest/policy.rs:20`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/ingest/policy.rs#L20)) |
-| Implementation | Key generation CLI: `eds keygen` ([`src/lib.rs — generate_keypair`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/lib.rs)) |
-| Implementation | Key inspection CLI: `eds inspect-key` ([`src/lib.rs — inspect_key`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/lib.rs)) |
+| Implementation | Public key registry: `IntegrityPolicyGate::register_device` ([`src/ingest/policy.rs:20`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/ingest/policy.rs#L20)) |
+| Implementation | Key generation CLI: `eds keygen` ([`src/lib.rs — generate_keypair`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/lib.rs)) |
+| Implementation | Key inspection CLI: `eds inspect-key` ([`src/lib.rs — inspect_key`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/lib.rs)) |
 | Implementation | Provisioning and rotation guidance: [Key Management](key_management.md) |
-| Note | HSM-backed key storage (CLS Level 4) is planned in [#54](https://github.com/yohei1126/edgesentry-rs/issues/54) |
+| Note | HSM-backed key storage (CLS Level 4) is planned in [#54](https://github.com/edgesentry/edgesentry-rs/issues/54) |
 
 ---
 
@@ -76,8 +76,8 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 | JC-STAR | STAR-1 R1.1 |
 | Requirement | Data must be transmitted with authenticity guarantees |
 | Status | ⚠️ Partial |
-| Implementation | Every `AuditRecord` carries an Ed25519 signature over its BLAKE3 payload hash — `build_signed_record` ([`src/agent.rs`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/agent.rs)), `sign_payload_hash` ([`src/identity.rs:12`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/identity.rs#L12)) |
-| Gap | Transport-layer encryption (TLS) is not in scope — record-level signature provides authenticity but not channel confidentiality. Tracked in [#73](https://github.com/yohei1126/edgesentry-rs/issues/73) |
+| Implementation | Every `AuditRecord` carries an Ed25519 signature over its BLAKE3 payload hash — `build_signed_record` ([`src/agent.rs`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/agent.rs)), `sign_payload_hash` ([`src/identity.rs:12`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/identity.rs#L12)) |
+| Gap | Transport-layer encryption (TLS) is not in scope — record-level signature provides authenticity but not channel confidentiality. Tracked in [#73](https://github.com/edgesentry/edgesentry-rs/issues/73) |
 
 ---
 
@@ -88,7 +88,7 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 | JC-STAR | STAR-1 R3.2 |
 | Requirement | Only necessary interfaces and services should be exposed |
 | Status | ⚠️ Partial |
-| Implementation | `NetworkPolicy` provides deny-by-default IP/CIDR allowlist enforcement — callers gate each ingest request through `NetworkPolicy::check(source_ip)` before invoking `IngestService` ([`src/ingest/network_policy.rs`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/ingest/network_policy.rs)) |
+| Implementation | `NetworkPolicy` provides deny-by-default IP/CIDR allowlist enforcement — callers gate each ingest request through `NetworkPolicy::check(source_ip)` before invoking `IngestService` ([`src/ingest/network_policy.rs`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/ingest/network_policy.rs)) |
 | Gap | The library does not expose a network service directly; transport-layer controls (VPN, firewall rules) remain the deployer's responsibility |
 
 ---
@@ -100,9 +100,9 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 | JC-STAR | STAR-1 R1.3 |
 | Requirement | The device must verify the integrity of software and data |
 | Status | ✅ Implemented |
-| Implementation — payload hash | BLAKE3 hash over raw payload: `compute_payload_hash` ([`src/integrity.rs:12`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/integrity.rs#L12)) |
-| Implementation — hash chain | `prev_record_hash` links each record to its predecessor; insertion/deletion detected by `verify_chain` ([`src/integrity.rs:35`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/integrity.rs#L35)) |
-| Tests | `tampered_lift_demo_chain_is_detected` ([`src/lib.rs:338`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/lib.rs#L338)) |
+| Implementation — payload hash | BLAKE3 hash over raw payload: `compute_payload_hash` ([`src/integrity.rs:12`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/integrity.rs#L12)) |
+| Implementation — hash chain | `prev_record_hash` links each record to its predecessor; insertion/deletion detected by `verify_chain` ([`src/integrity.rs:35`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/integrity.rs#L35)) |
+| Tests | `tampered_lift_demo_chain_is_detected` ([`src/lib.rs:338`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/lib.rs#L338)) |
 
 ---
 
@@ -123,7 +123,7 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 | JC-STAR | STAR-2 R3.2 |
 | Requirement | The device should remain operational and recover gracefully |
 | Status | ➖ Out of scope (partial path planned) |
-| Note | Full HA is a deployer responsibility, but the library can provide an offline buffer / store-and-forward module that accumulates signed records during connectivity loss and replays them in chain order when the link recovers. Tracked in [#74](https://github.com/yohei1126/edgesentry-rs/issues/74) |
+| Note | Full HA is a deployer responsibility, but the library can provide an offline buffer / store-and-forward module that accumulates signed records during connectivity loss and replays them in chain order when the link recovers. Tracked in [#74](https://github.com/edgesentry/edgesentry-rs/issues/74) |
 
 ---
 
@@ -134,8 +134,8 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 | JC-STAR | STAR-2 R3.1 |
 | Requirement | Security-relevant events must be logged and replay/reorder attacks must be detected |
 | Status | ✅ Implemented |
-| Implementation — sequence | Strict monotonic `sequence` per device; duplicates and out-of-order records rejected by `IngestState::verify_and_accept` ([`src/ingest/verify.rs:45`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/ingest/verify.rs#L45)) |
-| Implementation — audit trail | Accept/reject decisions persisted via `IngestService` and `AuditLedger` ([`src/ingest/storage.rs`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/ingest/storage.rs)) |
+| Implementation — sequence | Strict monotonic `sequence` per device; duplicates and out-of-order records rejected by `IngestState::verify_and_accept` ([`src/ingest/verify.rs:45`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/ingest/verify.rs#L45)) |
+| Implementation — audit trail | Accept/reject decisions persisted via `IngestService` and `AuditLedger` ([`src/ingest/storage.rs`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/ingest/storage.rs)) |
 
 ---
 
@@ -158,7 +158,7 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 | JC-STAR | STAR-2 R1.4 |
 | Requirement | Private keys must be stored and used inside an HSM |
 | Status | 🔲 Planned |
-| Gap | HSM-backed key storage planned for Phase 3 (IEC 62443-4-2 / CII/OT). See [#54](https://github.com/yohei1126/edgesentry-rs/issues/54) and [#98](https://github.com/yohei1126/edgesentry-rs/issues/98) |
+| Gap | HSM-backed key storage planned for Phase 3 (IEC 62443-4-2 / CII/OT). See [#54](https://github.com/edgesentry/edgesentry-rs/issues/54) and [#98](https://github.com/edgesentry/edgesentry-rs/issues/98) |
 
 ---
 
@@ -171,7 +171,7 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 | CLS | CLS-10 |
 | Requirement | Replay attacks must be detected and rejected |
 | Status | ✅ Implemented |
-| Implementation | `seen` HashSet in `IngestState` rejects duplicate `(device_id, sequence)` pairs ([`src/ingest/verify.rs:56`](https://github.com/yohei1126/edgesentry-rs/blob/main/crates/edgesentry-rs/src/ingest/verify.rs#L56)) |
+| Implementation | `seen` HashSet in `IngestState` rejects duplicate `(device_id, sequence)` pairs ([`src/ingest/verify.rs:56`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/ingest/verify.rs#L56)) |
 
 ---
 


### PR DESCRIPTION
## Summary

Repo transferred to https://github.com/edgesentry/edgesentry-rs. Updates all hardcoded URLs across source files:

- `Cargo.toml` — repository field
- `README.md` — repository and Pages links
- `docs/book.toml` — git-repository-url and edit-url-template
- `docs/src/*.md` — all issue links, source code links, and Pages references

The `target/` directory contains a cached artifact with an old unrelated URL — not tracked by git, no action needed.