### PR TITLE
fix(ci): grant write permissions to Claude Code Review action so it can post comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary

- `pull-requests` and `issues` were `read`-only in `claude-code-review.yml`, preventing the review action from posting inline review comments
- Changed both to `write`

## Root cause

Same class of issue as #106 — the action triggers and runs but silently fails when attempting to write back to the PR. `contents` remains `read` since the review action doesn't need to push code.

Fixes the failure seen in #92.