### PR TITLE
fix(ci): use ANTHROPIC_API_KEY instead of missing CLAUDE_CODE_OAUTH_TOKEN

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary

- Root cause of the `startup_failure` on the Claude Code workflow: `CLAUDE_CODE_OAUTH_TOKEN` secret does not exist in the repo
- Only `ANTHROPIC_API_KEY` and `CRATES_IO_TOKEN` are configured
- Switch `claude.yml` to use `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`, consistent with how `claude-code-review.yml` is already configured