### PR TITLE
fix(ci): trigger Claude on issue assignment

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,7 +16,7 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude') || (github.event.action == 'assigned' && github.event.assignee.login == 'claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -35,6 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          assignee_trigger: claude
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary

- The `if` condition for `issues` events only checked for `@claude` in the issue body/title — assigning an issue to the `claude` GitHub user had no effect
- Added `github.event.action == 'assigned' && github.event.assignee.login == 'claude'` to the condition
- Added `assignee_trigger: claude` input so the action also recognises assignment as the trigger source