### PR TITLE
debug(ci): enable show_full_output to diagnose Claude Code crash

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           assignee_trigger: claude
+          show_full_output: true
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
Temporary debug PR to see the actual Claude Code output before it crashes with exit code 1. Remove after diagnosis.