### PR TITLE
fix(ci): use CLAUDE_CODE_OAUTH_TOKEN and restrict to admin team

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,18 +25,32 @@ jobs:
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      - name: Check admin team membership
+        id: auth
+        run: |
+          STATE=$(gh api orgs/edgesentry/teams/admin/memberships/${{ github.actor }} --jq '.state' 2>/dev/null || echo "not_found")
+          if [[ "$STATE" == "active" ]]; then
+            echo "allowed=true" >> $GITHUB_OUTPUT
+          else
+            echo "allowed=false" >> $GITHUB_OUTPUT
+            echo "::notice::${{ github.actor }} is not in the admin team — skipping Claude."
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout repository
+        if: steps.auth.outputs.allowed == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
+        if: steps.auth.outputs.allowed == 'true'
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           assignee_trigger: claude
-          show_full_output: true
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'


### PR DESCRIPTION
## Summary

- Switch from `ANTHROPIC_API_KEY` (separate API billing) to `CLAUDE_CODE_OAUTH_TOKEN` (uses claude.ai Pro/Max subscription) — the API key was causing `billing_error` crashes
- Remove temporary `show_full_output: true` debug flag added in #111
- Re-add admin team membership gate (only members of edgesentry/admin team can trigger Claude)

## Required secret

Add `CLAUDE_CODE_OAUTH_TOKEN` to repository secrets. Run `claude setup-token` locally to generate the token.