### PR TITLE
docs: add GitHub community standard files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Something is broken or behaves incorrectly
+title: 'bug: '
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To reproduce
+
+Steps to reproduce the behaviour:
+
+1. ...
+2. ...
+
+## Expected behaviour
+
+What you expected to happen.
+
+## Actual behaviour
+
+What actually happened. Include any error messages, panics, or unexpected output.
+
+## Environment
+
+- `edgesentry-rs` version (or commit SHA):
+- Rust version (`rustc --version`):
+- OS and architecture:
+- Relevant feature flags enabled (`s3`, `postgres`, etc.):
+
+## Additional context
+
+Add any other context about the problem here (logs, stack traces, minimal reproducible example).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/edgesentry/edgesentry-rs/security/advisories/new
+    about: Please report security vulnerabilities privately — do not open a public issue.
+  - name: Documentation
+    url: https://github.com/edgesentry/edgesentry-rs/blob/main/docs/src/contributing.md
+    about: Read the contributing guide before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: New feature or improvement to existing behaviour
+title: 'feat: '
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+A clear and concise description of what you want to happen.
+
+## Motivation
+
+Why is this needed? Which compliance requirement, use case, or pain point does it address?
+
+## Proposed solution
+
+Describe the solution you would like. Include API sketches, data structures, or pseudocode if helpful.
+
+## Alternatives considered
+
+Any alternative approaches you have considered and why you ruled them out.
+
+## Compliance relevance (if applicable)
+
+Does this relate to a specific CLS clause, JC-STAR requirement, or ETSI EN 303 645 provision? If so, list them here so the issue can be linked to the traceability matrix.
+
+## Additional context
+
+Add any other context, references, or screenshots here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- One or two sentences describing what this PR does and why. -->
+
+## Related issue
+
+<!-- Link the issue this PR closes, e.g. Closes #123 -->
+
+Closes #
+
+## Changes
+
+<!-- Bullet list of the key changes. -->
+
+-
+
+## Checklist
+
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
+- [ ] `cargo deny check licenses` passes
+- [ ] Docs updated if behaviour changed (`concepts.md`, `traceability.md`, CLI docs, etc.)
+- [ ] Issue labels on this PR match the [label guide](docs/src/contributing.md#issue-labels) (type + priority + category)
+- [ ] PR assigned to the author (`--assignee "@me"`)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, colour, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologising to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behaviour:
+
+- The use of sexualised language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behaviour and will take appropriate and fair corrective action in response to any behaviour that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the community leaders responsible for enforcement via the contact method listed in [SECURITY.md](SECURITY.md). All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+Full contribution guidelines are in [docs/src/contributing.md](docs/src/contributing.md) (English) and [docs/ja/src/contributing.md](docs/ja/src/contributing.md) (日本語).
+
+## Quick start
+
+```bash
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo deny check licenses
+```
+
+## Reporting a vulnerability
+
+Please see [SECURITY.md](SECURITY.md). Do not open a public issue for security vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| 0.x (current) | ✅ |
+
+Only the latest published version on crates.io receives security updates. Patch releases are issued for confirmed vulnerabilities; update to the latest patch version as soon as possible.
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub issue for security vulnerabilities.**
+
+Report security issues privately using [GitHub's private vulnerability reporting](https://github.com/edgesentry/edgesentry-rs/security/advisories/new).
+
+Include as much of the following as possible:
+
+- Description of the vulnerability and its potential impact
+- Steps to reproduce or a minimal proof-of-concept
+- Affected version(s) and component(s) (`edgesentry-rs`, `edgesentry-bridge`, etc.)
+- Any suggested mitigations you have identified
+
+### Response timeline
+
+| Stage | Target |
+| ----- | ------ |
+| Acknowledgement | Within 3 business days |
+| Triage and severity assessment | Within 7 business days |
+| Patch or mitigation plan communicated | Within 30 days (critical / high); 90 days (medium / low) |
+| Public disclosure | After patch is available and reporter is notified |
+
+If a reported vulnerability is accepted, we will credit the reporter in the release notes unless they prefer to remain anonymous.
+
+If a reported vulnerability is declined (e.g. out of scope, not reproducible, or working as intended), we will explain our reasoning within the response timeline above.
+
+### Scope
+
+In scope:
+
+- Cryptographic correctness in `edgesentry-rs` (Ed25519 signing, BLAKE3 hashing, hash-chain verification)
+- Ingest pipeline integrity and authentication controls
+- FFI memory safety in `edgesentry-bridge`
+- Supply-chain security issues in direct dependencies
+
+Out of scope:
+
+- Vulnerabilities in transitive dependencies not exploitable through `edgesentry-rs`'s public API
+- Issues requiring physical device access (report to the relevant hardware vendor)
+- Denial-of-service issues with no cryptographic or integrity impact


### PR DESCRIPTION
## Summary

Adds all files GitHub surfaces under **Insights → Community Standards**, closing #64 and #123.

## Related issue

Closes #64
Closes #123

## Changes

- **`SECURITY.md`** — supported versions table, private reporting via GitHub Security Advisories, response SLA (3 bd ack / 7 bd triage / 30–90 d patch), in/out-of-scope definition
- **`CONTRIBUTING.md`** — root stub pointing to `docs/src/contributing.md` (EN) and `docs/ja/src/contributing.md` (JA); no duplication of content
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1
- **`.github/ISSUE_TEMPLATE/bug_report.md`** — structured bug template with env fields
- **`.github/ISSUE_TEMPLATE/feature_request.md`** — feature request template with compliance-relevance field
- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues, links to private security reporting and contributing guide
- **`.github/pull_request_template.md`** — checklist: tests, Clippy, cargo-deny, docs, labels, assignee

## Checklist

- [x] `cargo test --workspace` passes (docs-only change)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo deny check licenses` passes
- [x] No production code changed
- [x] Issue labels on this PR match the label guide (documentation + compliance-governance + priority:P1)
- [x] PR assigned to the author

🤖 Generated with [Claude Code](https://claude.com/claude-code)