### PR TITLE
feat(observability): add tracing instrumentation and operations runbook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,6 +981,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ clap = { version = "4.5", features = ["derive"] }
 serde_json = "1"
 hex = "0.4"
 rand = "0.8"
+tracing = "0.1"

--- a/crates/edgesentry-rs/Cargo.toml
+++ b/crates/edgesentry-rs/Cargo.toml
@@ -34,6 +34,7 @@ rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 aws-config = { version = "1", optional = true }
 aws-sdk-s3 = { version = "1", optional = true }
 aws-credential-types = { version = "1", optional = true }

--- a/crates/edgesentry-rs/src/agent.rs
+++ b/crates/edgesentry-rs/src/agent.rs
@@ -1,4 +1,5 @@
 use ed25519_dalek::SigningKey;
+use tracing::debug;
 
 use crate::identity::sign_payload_hash;
 use crate::integrity::compute_payload_hash;
@@ -13,16 +14,21 @@ pub fn build_signed_record(
     object_ref: impl Into<String>,
     signing_key: &SigningKey,
 ) -> AuditRecord {
+    let device_id = device_id.into();
+    let object_ref = object_ref.into();
+
+    debug!(device_id, sequence, payload_bytes = payload.len(), "signing record");
+
     let payload_hash = compute_payload_hash(payload);
     let signature = sign_payload_hash(signing_key, &payload_hash);
 
     AuditRecord {
-        device_id: device_id.into(),
+        device_id,
         sequence,
         timestamp_ms,
         payload_hash,
         signature,
         prev_record_hash,
-        object_ref: object_ref.into(),
+        object_ref,
     }
 }

--- a/crates/edgesentry-rs/src/ingest/storage.rs
+++ b/crates/edgesentry-rs/src/ingest/storage.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use thiserror::Error;
+use tracing::{debug, error, info, instrument, warn};
 
 use crate::integrity::compute_payload_hash;
 use crate::record::AuditRecord;
@@ -84,9 +85,17 @@ where
         self.policy.register_device(device_id, key);
     }
 
+    #[instrument(skip(self, raw_payload), fields(
+        device_id = %record.device_id,
+        sequence  = record.sequence,
+        object_ref = %record.object_ref,
+    ))]
     pub fn ingest(&mut self, record: AuditRecord, raw_payload: &[u8], cert_identity: Option<&str>) -> Result<(), IngestServiceError> {
+        debug!(payload_bytes = raw_payload.len(), "ingest started");
+
         let payload_hash = compute_payload_hash(raw_payload);
         if payload_hash != record.payload_hash {
+            warn!("payload hash mismatch — record rejected");
             self.log_rejection(&record, "payload hash mismatch");
             return Err(IngestServiceError::PayloadHashMismatch {
                 device_id: record.device_id,
@@ -95,17 +104,24 @@ where
         }
 
         if let Err(error) = self.policy.enforce(&record, cert_identity) {
+            warn!(reason = %error, "integrity policy rejected record");
             self.log_rejection(&record, &error.to_string());
             return Err(IngestServiceError::Verify(error));
         }
 
         self.raw_data_store
             .put(&record.object_ref, raw_payload)
-            .map_err(|e| IngestServiceError::RawDataStore(e.to_string()))?;
+            .map_err(|e| {
+                error!(error = %e, "raw data store write failed");
+                IngestServiceError::RawDataStore(e.to_string())
+            })?;
 
         self.audit_ledger
             .append(record.clone())
-            .map_err(|e| IngestServiceError::AuditLedger(e.to_string()))?;
+            .map_err(|e| {
+                error!(error = %e, "audit ledger append failed");
+                IngestServiceError::AuditLedger(e.to_string())
+            })?;
 
         self.operation_log
             .write(OperationLogEntry {
@@ -114,8 +130,12 @@ where
                 sequence: record.sequence,
                 message: "ingest accepted".to_string(),
             })
-            .map_err(|e| IngestServiceError::OperationLog(e.to_string()))?;
+            .map_err(|e| {
+                error!(error = %e, "operation log write failed");
+                IngestServiceError::OperationLog(e.to_string())
+            })?;
 
+        info!("record accepted");
         Ok(())
     }
 

--- a/crates/edgesentry-rs/src/ingest/verify.rs
+++ b/crates/edgesentry-rs/src/ingest/verify.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use ed25519_dalek::VerifyingKey;
 use thiserror::Error;
+use tracing::debug;
 
 use crate::identity::verify_payload_signature;
 use crate::record::{AuditRecord, Hash32};
@@ -50,10 +51,12 @@ impl IngestState {
             .ok_or_else(|| IngestError::UnknownDevice(device_id.clone()))?;
 
         if !verify_payload_signature(key, &record.payload_hash, &record.signature) {
+            debug!(device_id, sequence = record.sequence, "signature verification failed");
             return Err(IngestError::InvalidSignature(device_id.clone()));
         }
 
         if self.seen.contains(&(device_id.clone(), record.sequence)) {
+            debug!(device_id, sequence = record.sequence, "duplicate record rejected");
             return Err(IngestError::Duplicate {
                 device_id: device_id.clone(),
                 sequence: record.sequence,
@@ -65,6 +68,7 @@ impl IngestState {
             .get(device_id)
             .map_or(1, |prev| prev.saturating_add(1));
         if record.sequence != expected_sequence {
+            debug!(device_id, expected = expected_sequence, actual = record.sequence, "sequence out of order");
             return Err(IngestError::InvalidSequence {
                 device_id: device_id.clone(),
                 expected: expected_sequence,
@@ -79,6 +83,7 @@ impl IngestState {
             .unwrap_or_else(AuditRecord::zero_hash);
 
         if record.prev_record_hash != expected_prev_hash {
+            debug!(device_id, sequence = record.sequence, "prev_record_hash mismatch — chain broken");
             return Err(IngestError::InvalidPrevHash(device_id.clone()));
         }
 
@@ -86,6 +91,7 @@ impl IngestState {
         self.last_sequence.insert(device_id.clone(), record.sequence);
         self.last_hash.insert(device_id.clone(), record.hash());
 
+        debug!(device_id, sequence = record.sequence, "record verified and accepted");
         Ok(())
     }
 }

--- a/docs/ja/src/SUMMARY.md
+++ b/docs/ja/src/SUMMARY.md
@@ -13,3 +13,4 @@
 - [C/C++ FFI ブリッジ](ffi_bridge.md)
 - [プロジェクトへの貢献](contributing.md)
 - [ビルドとリリース](release.md)
+- [運用ランブック](operations.md)

--- a/docs/ja/src/operations.md
+++ b/docs/ja/src/operations.md
@@ -1,0 +1,218 @@
+# 運用ランブック
+
+このページでは、EdgeSentry-RS の本番環境デプロイにおけるオブザーバビリティの設定、アラート閾値、バックアップ・リストア手順を説明します。
+
+---
+
+## オブザーバビリティ
+
+### `tracing` を使った構造化ログ
+
+EdgeSentry-RS は [`tracing`](https://docs.rs/tracing) ファサードを使用しています。サブスクライバーはバンドルされていません。デプロイ側がアプリケーション起動時に任意のバックエンドを接続します。サブスクライバーが登録されていない場合、ライブラリのオーバーヘッドはゼロです。
+
+**本番環境向け推奨サブスクライバー（JSON を stdout に出力し、Loki / CloudWatch に取り込む）：**
+
+```toml
+# ホストアプリケーションの Cargo.toml
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+```
+
+```rust
+use tracing_subscriber::{fmt, EnvFilter};
+
+fn main() {
+    fmt()
+        .json()
+        .with_env_filter(EnvFilter::from_default_env()) // RUST_LOG=edgesentry_rs=info
+        .init();
+    // ...
+}
+```
+
+本番環境では `RUST_LOG=edgesentry_rs=info`、インシデント調査時は `edgesentry_rs=debug` を設定してください。
+
+### ライブラリが出力する構造化ログイベント
+
+すべてのイベントにはモジュールパスが `target` として含まれます。主要なイベントの一覧：
+
+| レベル | ターゲット | イベント | 主要フィールド |
+|--------|-----------|---------|---------------|
+| `DEBUG` | `edgesentry_rs::agent` | `signing record` | `device_id`, `sequence`, `payload_bytes` |
+| `DEBUG` | `edgesentry_rs::ingest::storage` | `ingest started` | `device_id`, `sequence`, `object_ref`, `payload_bytes` |
+| `WARN`  | `edgesentry_rs::ingest::storage` | `payload hash mismatch — record rejected` | `device_id`, `sequence` |
+| `WARN`  | `edgesentry_rs::ingest::storage` | `integrity policy rejected record` | `device_id`, `sequence`, `reason` |
+| `ERROR` | `edgesentry_rs::ingest::storage` | `raw data store write failed` | `device_id`, `sequence`, `error` |
+| `ERROR` | `edgesentry_rs::ingest::storage` | `audit ledger append failed` | `device_id`, `sequence`, `error` |
+| `ERROR` | `edgesentry_rs::ingest::storage` | `operation log write failed` | `device_id`, `sequence`, `error` |
+| `INFO`  | `edgesentry_rs::ingest::storage` | `record accepted` | `device_id`, `sequence`, `object_ref` |
+| `DEBUG` | `edgesentry_rs::ingest::verify` | `signature verification failed` | `device_id`, `sequence` |
+| `DEBUG` | `edgesentry_rs::ingest::verify` | `duplicate record rejected` | `device_id`, `sequence` |
+| `DEBUG` | `edgesentry_rs::ingest::verify` | `sequence out of order` | `device_id`, `expected`, `actual` |
+| `DEBUG` | `edgesentry_rs::ingest::verify` | `prev_record_hash mismatch — chain broken` | `device_id`, `sequence` |
+| `DEBUG` | `edgesentry_rs::ingest::verify` | `record verified and accepted` | `device_id`, `sequence` |
+
+### 推奨 Prometheus メトリクス（ログから導出）
+
+ログ→メトリクスパイプライン（Promtail + Loki、または Vector など）を使い、構造化ログイベントからカウンターを導出します：
+
+| メトリクス | 導出方法 | アラート閾値 |
+|-----------|---------|------------|
+| `edgesentry_ingest_accepted_total` | `INFO "record accepted"` イベントをカウント | — |
+| `edgesentry_ingest_rejected_total{reason}` | `WARN` 拒否イベントを `reason` フィールドでラベル付けしてカウント | 10件/分を継続 → P1 アラート |
+| `edgesentry_ingest_error_total{component}` | `ERROR` ストレージ障害イベントをコンポーネント別にカウント | 1件でも発生 → P0 アラート |
+| `edgesentry_chain_break_total` | `DEBUG "prev_record_hash mismatch"` イベントをカウント | 1件でも発生 → P0 アラート |
+| `edgesentry_signature_fail_total` | `DEBUG "signature verification failed"` イベントをカウント | 5件/分を継続 → P1 アラート |
+
+### OpenTelemetry（トレーシングスパン）
+
+`IngestService::ingest` メソッドは `tracing` スパンを出力します。OTLP エクスポーターに接続することで分散トレーシングが利用できます：
+
+```toml
+opentelemetry = "0.26"
+opentelemetry-otlp = { version = "0.26", features = ["grpc-tonic"] }
+tracing-opentelemetry = "0.27"
+```
+
+---
+
+## アラート定義
+
+| アラート | 条件 | 重要度 | 対応 |
+|---------|------|--------|------|
+| `IngestStorageError` | `ERROR` レベルのストレージ障害が発生 | P0 | DB/S3 接続を確認し、ディスクと認証情報を検証する |
+| `ChainBreak` | `prev_record_hash mismatch` イベントが発生 | P0 | 改ざんまたはリプレイを調査し、再起動前にログを保全する |
+| `HighRejectionRate` | 拒否率が 5 分間 10件/分を超過 | P1 | デバイスファームウェアを確認し、署名鍵のローテーション設定を調査する |
+| `SignatureFailureSurge` | 署名失敗が 5 分間 5件/分を超過 | P1 | 鍵の漏洩またはアクティブなスプーフィングの可能性を調査する |
+| `AuditLedgerLag` | Postgres `operation_logs` 挿入レイテンシの p99 が 2 秒超 | P1 | DBのクエリプランと autovacuum の競合を確認する |
+
+---
+
+## 復旧目標
+
+| 目標 | ターゲット | 根拠 |
+|------|-----------|------|
+| RTO（復旧時間目標） | 30 分以内 | pg_basebackup + WAL リプレイによるリストア時間 |
+| RPO（復旧時点目標） | 5 分以内 | 5 分間隔の継続的 WAL アーカイブ |
+
+---
+
+## バックアップ手順
+
+### PostgreSQL — 監査台帳・操作ログ
+
+**前提条件：** WAL アーカイブが有効化されていること（`archive_mode = on`、`archive_command` で S3 等に転送）。
+
+#### 1. ベースバックアップの取得
+
+```bash
+pg_basebackup \
+  --host=<DB_HOST> \
+  --username=<DB_USER> \
+  --pgdata=/backup/pg_base_$(date +%Y%m%d_%H%M%S) \
+  --format=tar \
+  --gzip \
+  --wal-method=stream \
+  --checkpoint=fast \
+  --progress
+```
+
+#### 2. バックアップの検証
+
+```bash
+pg_restore --list /backup/pg_base_<timestamp>/base.tar.gz | head -20
+```
+
+#### 3. WAL の継続アーカイブ
+
+`postgresql.conf` の `archive_command` が WAL セグメントを耐久性のあるストレージ（例：S3）に転送していることを確認します：
+
+```
+archive_command = 'aws s3 cp %p s3://<BUCKET>/wal/%f'
+```
+
+#### 4. 保持ポリシー
+
+| バックアップ種別 | 保持期間 |
+|----------------|---------|
+| ベースバックアップ | 30 日 |
+| WAL アーカイブ | 30 日 |
+| 論理ダンプ（`pg_dump`） | 7 日（週次） |
+
+---
+
+### S3 / MinIO — ペイロード生データストア
+
+バケットで**バージョニング**と**クロスリージョンレプリケーション**を有効化します：
+
+```bash
+# バージョニングの有効化
+aws s3api put-bucket-versioning \
+  --bucket <BUCKET> \
+  --versioning-configuration Status=Enabled
+
+# レプリケーションの有効化（宛先バケットと IAM ロールを別途設定した上で）
+aws s3api put-bucket-replication \
+  --bucket <BUCKET> \
+  --replication-configuration file://replication.json
+```
+
+最低限のレプリケーション先：別リージョン 1 か所。CLS Level 3 のエビデンス完全性を確保するため、オブジェクトロックまたはバージョニングを有効化し、ペイロードが上書き削除されないようにします。
+
+---
+
+## リストア手順
+
+### PostgreSQL — ポイントインタイムリカバリ（PITR）
+
+```bash
+# 1. Postgres サービスを停止
+systemctl stop postgresql
+
+# 2. ベースバックアップを展開
+tar -xzf /backup/pg_base_<timestamp>/base.tar.gz -C /var/lib/postgresql/data/
+
+# 3. リカバリ設定を作成
+cat > /var/lib/postgresql/data/recovery.conf <<EOF
+restore_command = 'aws s3 cp s3://<BUCKET>/wal/%f %p'
+recovery_target_time = '<TARGET_TIMESTAMP>'
+recovery_target_action = 'promote'
+EOF
+
+# 4. Postgres を起動 — 指定時刻まで WAL をリプレイする
+systemctl start postgresql
+
+# 5. 確認：デバイスごとの最終受理シーケンスを確認
+psql -U <DB_USER> -d <DB_NAME> \
+  -c "SELECT device_id, MAX(sequence) FROM audit_records GROUP BY device_id;"
+```
+
+#### 復旧確認チェックリスト
+
+- [ ] デバイスごとの最終シーケンスがインシデント前のスナップショットと一致する
+- [ ] ハッシュチェーンの連続性を確認：`eds verify-chain <exported-records.json>`
+- [ ] 操作ログにリカバリ対象時刻前後のギャップがないことを確認する
+- [ ] 確認完了後、アラート抑制を解除する
+
+### S3 / MinIO — オブジェクトのリストア
+
+```bash
+# 特定バージョンのオブジェクトをリストア
+aws s3api get-object \
+  --bucket <BUCKET> \
+  --key <OBJECT_KEY> \
+  --version-id <VERSION_ID> \
+  <OUTPUT_FILE>
+```
+
+---
+
+## 障害訓練スケジュール
+
+以下の訓練を四半期ごとに実施し、ランブックの正確性を検証します：
+
+| 訓練 | 手順 | 合格基準 |
+|------|------|---------|
+| DB フェイルオーバー | プライマリ Postgres を停止してレプリカを昇格 | 30 分以内にインジェストが再開 |
+| DB リストア | ステージング環境で 1 時間前への PITR を実施 | 30 分以内にチェーン連続性を確認 |
+| S3 オブジェクト復旧 | 削除したテストオブジェクトをリストア | バイト単位で元のオブジェクトと一致 |
+| アラート発火 | テストハーネスで不正な署名を注入 | 2 分以内に P1 アラートが発火 |

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -13,3 +13,4 @@
 - [C/C++ FFI Bridge](ffi_bridge.md)
 - [Contributing](contributing.md)
 - [Build and Release](release.md)
+- [Operations Runbook](operations.md)

--- a/docs/src/operations.md
+++ b/docs/src/operations.md
@@ -1,0 +1,218 @@
+# Operations Runbook
+
+This page covers observability wiring, alert thresholds, and backup/restore procedures for a production EdgeSentry-RS deployment.
+
+---
+
+## Observability
+
+### Structured logging with `tracing`
+
+EdgeSentry-RS uses the [`tracing`](https://docs.rs/tracing) facade. No subscriber is bundled — deployers wire up the backend of their choice at application startup. The library emits zero overhead when no subscriber is registered.
+
+**Recommended subscriber for production (JSON over stdout, ingested by Loki / CloudWatch):**
+
+```toml
+# Cargo.toml of the host application
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+```
+
+```rust
+use tracing_subscriber::{fmt, EnvFilter};
+
+fn main() {
+    fmt()
+        .json()
+        .with_env_filter(EnvFilter::from_default_env()) // RUST_LOG=edgesentry_rs=info
+        .init();
+    // ...
+}
+```
+
+Set `RUST_LOG=edgesentry_rs=info` for production; `edgesentry_rs=debug` for incident investigation.
+
+### Structured log events emitted by the library
+
+All events include the module path as `target`. Key events:
+
+| Level | Target | Event | Key fields |
+|-------|--------|-------|-----------|
+| `DEBUG` | `edgesentry_rs::agent` | `signing record` | `device_id`, `sequence`, `payload_bytes` |
+| `DEBUG` | `edgesentry_rs::ingest::storage` | `ingest started` | `device_id`, `sequence`, `object_ref`, `payload_bytes` |
+| `WARN`  | `edgesentry_rs::ingest::storage` | `payload hash mismatch — record rejected` | `device_id`, `sequence` |
+| `WARN`  | `edgesentry_rs::ingest::storage` | `integrity policy rejected record` | `device_id`, `sequence`, `reason` |
+| `ERROR` | `edgesentry_rs::ingest::storage` | `raw data store write failed` | `device_id`, `sequence`, `error` |
+| `ERROR` | `edgesentry_rs::ingest::storage` | `audit ledger append failed` | `device_id`, `sequence`, `error` |
+| `ERROR` | `edgesentry_rs::ingest::storage` | `operation log write failed` | `device_id`, `sequence`, `error` |
+| `INFO`  | `edgesentry_rs::ingest::storage` | `record accepted` | `device_id`, `sequence`, `object_ref` |
+| `DEBUG` | `edgesentry_rs::ingest::verify` | `signature verification failed` | `device_id`, `sequence` |
+| `DEBUG` | `edgesentry_rs::ingest::verify` | `duplicate record rejected` | `device_id`, `sequence` |
+| `DEBUG` | `edgesentry_rs::ingest::verify` | `sequence out of order` | `device_id`, `expected`, `actual` |
+| `DEBUG` | `edgesentry_rs::ingest::verify` | `prev_record_hash mismatch — chain broken` | `device_id`, `sequence` |
+| `DEBUG` | `edgesentry_rs::ingest::verify` | `record verified and accepted` | `device_id`, `sequence` |
+
+### Recommended Prometheus metrics (derived from logs)
+
+Use a log-to-metrics pipeline (e.g. Promtail + Loki, or Vector) to derive counters from structured log events:
+
+| Metric | How to derive | Alert threshold |
+|--------|--------------|-----------------|
+| `edgesentry_ingest_accepted_total` | Count `INFO "record accepted"` events | — |
+| `edgesentry_ingest_rejected_total{reason}` | Count `WARN` rejection events, label by `reason` field | > 10/min sustained → P1 alert |
+| `edgesentry_ingest_error_total{component}` | Count `ERROR` storage failure events, label by `component` (raw_data_store / audit_ledger / operation_log) | Any occurrence → P0 alert |
+| `edgesentry_chain_break_total` | Count `DEBUG "prev_record_hash mismatch"` events | Any occurrence → P0 alert |
+| `edgesentry_signature_fail_total` | Count `DEBUG "signature verification failed"` events | > 5/min sustained → P1 alert |
+
+### OpenTelemetry (tracing spans)
+
+The `IngestService::ingest` method emits a `tracing` span. Wire it to an OTLP exporter for distributed tracing:
+
+```toml
+opentelemetry = "0.26"
+opentelemetry-otlp = { version = "0.26", features = ["grpc-tonic"] }
+tracing-opentelemetry = "0.27"
+```
+
+---
+
+## Alert Definitions
+
+| Alert | Condition | Severity | Response |
+|-------|-----------|----------|----------|
+| `IngestStorageError` | Any `ERROR`-level storage failure | P0 | Check DB/S3 connectivity; verify disk and credentials |
+| `ChainBreak` | Any `prev_record_hash mismatch` event | P0 | Investigate tamper or replay; preserve logs before any restart |
+| `HighRejectionRate` | Rejection rate > 10/min for 5 min | P1 | Check device firmware; look for misconfigured signing key rotation |
+| `SignatureFailureSurge` | Signature failures > 5/min for 5 min | P1 | Possible key compromise or active spoofing attempt |
+| `AuditLedgerLag` | Postgres `operation_logs` insert latency > 2 s p99 | P1 | Check DB query plan; autovacuum contention |
+
+---
+
+## Recovery Objectives
+
+| Objective | Target | Basis |
+|-----------|--------|-------|
+| RTO (recovery time) | < 30 minutes | Time to restore Postgres from pg_basebackup + WAL replay |
+| RPO (recovery point) | < 5 minutes | Continuous WAL archiving at 5-minute intervals |
+
+---
+
+## Backup Runbook
+
+### PostgreSQL — audit ledger and operation log
+
+**Prerequisites:** WAL archiving enabled (`archive_mode = on`, `archive_command` shipping to S3 or equivalent).
+
+#### 1. Take a base backup
+
+```bash
+pg_basebackup \
+  --host=<DB_HOST> \
+  --username=<DB_USER> \
+  --pgdata=/backup/pg_base_$(date +%Y%m%d_%H%M%S) \
+  --format=tar \
+  --gzip \
+  --wal-method=stream \
+  --checkpoint=fast \
+  --progress
+```
+
+#### 2. Verify the backup
+
+```bash
+pg_restore --list /backup/pg_base_<timestamp>/base.tar.gz | head -20
+```
+
+#### 3. Archive WAL continuously
+
+Ensure the `archive_command` in `postgresql.conf` ships WAL segments to durable storage (e.g. S3):
+
+```
+archive_command = 'aws s3 cp %p s3://<BUCKET>/wal/%f'
+```
+
+#### 4. Retention policy
+
+| Backup type | Retention |
+|-------------|-----------|
+| Base backup | 30 days |
+| WAL archive | 30 days |
+| Logical dump (`pg_dump`) | 7 days (weekly) |
+
+---
+
+### S3 / MinIO — raw payload store
+
+Enable **versioning** and **cross-region replication** on the bucket:
+
+```bash
+# Enable versioning
+aws s3api put-bucket-versioning \
+  --bucket <BUCKET> \
+  --versioning-configuration Status=Enabled
+
+# Enable replication (requires a destination bucket and IAM role configured separately)
+aws s3api put-bucket-replication \
+  --bucket <BUCKET> \
+  --replication-configuration file://replication.json
+```
+
+Minimum replication target: one additional region. For CLS Level 3 evidence integrity, ensure object lock or versioning is enabled so payloads cannot be silently overwritten.
+
+---
+
+## Restore Runbook
+
+### PostgreSQL — point-in-time recovery (PITR)
+
+```bash
+# 1. Stop the Postgres service
+systemctl stop postgresql
+
+# 2. Restore base backup
+tar -xzf /backup/pg_base_<timestamp>/base.tar.gz -C /var/lib/postgresql/data/
+
+# 3. Create recovery config
+cat > /var/lib/postgresql/data/recovery.conf <<EOF
+restore_command = 'aws s3 cp s3://<BUCKET>/wal/%f %p'
+recovery_target_time = '<TARGET_TIMESTAMP>'
+recovery_target_action = 'promote'
+EOF
+
+# 4. Start Postgres — it will replay WAL to the target time
+systemctl start postgresql
+
+# 5. Verify: query the last accepted sequence per device
+psql -U <DB_USER> -d <DB_NAME> \
+  -c "SELECT device_id, MAX(sequence) FROM audit_records GROUP BY device_id;"
+```
+
+#### Recovery verification checklist
+
+- [ ] Last record sequence per device matches pre-incident snapshot
+- [ ] Hash chain continuity verified: `eds verify-chain <exported-records.json>`
+- [ ] Operation log shows no unexpected gaps (check timestamps around recovery target)
+- [ ] Alert suppression lifted after verification completes
+
+### S3 / MinIO — object restore
+
+```bash
+# Restore a specific object version
+aws s3api get-object \
+  --bucket <BUCKET> \
+  --key <OBJECT_KEY> \
+  --version-id <VERSION_ID> \
+  <OUTPUT_FILE>
+```
+
+---
+
+## Failure Drill Schedule
+
+Run the following drills quarterly to verify runbook accuracy:
+
+| Drill | Procedure | Pass criterion |
+|-------|-----------|---------------|
+| DB failover | Stop primary Postgres; promote replica | Ingest resumes in < 30 min |
+| DB restore | PITR to 1 hour ago on staging | Chain continuity verified in < 30 min |
+| S3 object recovery | Restore a deleted test object | Object byte-identical to original |
+| Alert fire | Inject a bad signature via test harness | P1 alert fires within 2 min |


### PR DESCRIPTION
## Summary

Implements the P0 operations baseline (closes #15) with structured `tracing` instrumentation across the ingest pipeline and a full operations runbook.

## Related issue

Closes #15

## Changes

### Code
- **`Cargo.toml`** — add `tracing = "0.1"` as workspace dependency
- **`src/agent.rs`** — `DEBUG` event on record signing (`device_id`, `sequence`, `payload_bytes`)
- **`src/ingest/verify.rs`** — `DEBUG` events on every rejection path: signature fail, duplicate, sequence out of order, hash-chain break; `DEBUG` on accept
- **`src/ingest/storage.rs`** — `#[instrument]` span on `IngestService::ingest` with `device_id`/`sequence`/`object_ref` fields; `DEBUG` on start, `WARN` on rejections, `ERROR` on storage failures, `INFO` on accept

### Documentation (`docs/src/operations.md` + `docs/ja/src/operations.md`)
- Subscriber wiring guide (JSON stdout → Loki/CloudWatch)
- Full structured log event catalogue with levels and fields
- Derived Prometheus metrics table with alert thresholds
- Alert definitions: `IngestStorageError` (P0), `ChainBreak` (P0), `HighRejectionRate` (P1), `SignatureFailureSurge` (P1), `AuditLedgerLag` (P1)
- RTO < 30 min / RPO < 5 min targets
- PostgreSQL PITR backup and restore runbook (pg_basebackup + WAL archiving)
- S3/MinIO versioning and object restore runbook
- Quarterly failure drill schedule

## Checklist

- [x] `cargo test --workspace --all-features` — 60 tests pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes
- [x] `cargo deny check licenses` passes
- [x] Both EN and JA docs updated
- [x] Both SUMMARY.md files updated
- [x] Issue labels match label guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)