### PR TITLE
docs(cls-02): mark vulnerability disclosure as implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ An early-stage learning project building tamper-evident audit log infrastructure
 | [Contributing](docs/src/contributing.md) | Prerequisites, tests, static analysis, PR conventions |
 | [Build and Release](docs/src/release.md) | Release pipeline and version automation |
 
+## Security
+
+To report a vulnerability privately, use [GitHub's private vulnerability reporting](https://github.com/edgesentry/edgesentry-rs/security/advisories/new). See [SECURITY.md](SECURITY.md) for the full disclosure policy, supported versions, response SLAs, and scope.
+
 ## License
 
 This project is licensed under either of:

--- a/docs/ja/src/traceability.md
+++ b/docs/ja/src/traceability.md
@@ -42,8 +42,9 @@
 |------|--------|
 | JC-STAR | STAR-1 R4.1 |
 | 要件 | SLA が定められた、公開・実行可能な脆弱性報告チャネル |
-| ステータス | ⚠️ 部分的 |
-| ギャップ | 正式な開示プロセスが未定義。[#58](https://github.com/edgesentry/edgesentry-rs/issues/58)を参照 |
+| ステータス | ✅ 実装済み |
+| 実装 | [`SECURITY.md`](https://github.com/edgesentry/edgesentry-rs/blob/main/SECURITY.md) — 対応バージョン・プライベート報告窓口（GitHub Security Advisory）・承認 SLA（3営業日）・パッチ SLA（重大/高: 30日、中/低: 90日）・スコープ定義を含む公開開示ポリシー |
+| 実装 | GitHub プライベート脆弱性報告機能を有効化済み — 報告者は [Security Advisories](https://github.com/edgesentry/edgesentry-rs/security/advisories/new) フォームを使用 |
 
 ---
 
@@ -184,7 +185,7 @@
 
 | レベル | 総条項数 | ✅ 実装済み | ⚠️ 部分的 | 🔲 計画中 | ➖ スコープ外 |
 |-------|-------------|--------------|-----------|-----------|----------------|
-| CLS レベル 3 | 11 | 3 | 4 | 0 | 4 |
+| CLS レベル 3 | 11 | 4 | 3 | 0 | 4 |
 | CLS レベル 4 | 1 | 0 | 0 | 1 | 0 |
 | JC-STAR 追加 | 1 | 1 | 0 | 0 | 0 |
 

--- a/docs/src/traceability.md
+++ b/docs/src/traceability.md
@@ -42,8 +42,9 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 |------|--------|
 | JC-STAR | STAR-1 R4.1 |
 | Requirement | A published, actionable vulnerability reporting channel with defined SLAs |
-| Status | ⚠️ Partial |
-| Gap | Formal disclosure process not yet defined. See [#58](https://github.com/edgesentry/edgesentry-rs/issues/58) |
+| Status | ✅ Implemented |
+| Implementation | [`SECURITY.md`](https://github.com/edgesentry/edgesentry-rs/blob/main/SECURITY.md) — published disclosure policy with supported versions, private reporting via GitHub advisory, acknowledgement SLA (3 business days), patch SLA (30 days critical/high; 90 days medium/low), and defined in/out-of-scope |
+| Implementation | GitHub private vulnerability reporting enabled — reporters use the [Security Advisories](https://github.com/edgesentry/edgesentry-rs/security/advisories/new) form |
 
 ---
 
@@ -184,7 +185,7 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 
 | Level | Total clauses | ✅ Implemented | ⚠️ Partial | 🔲 Planned | ➖ Out of scope |
 |-------|-------------|--------------|-----------|-----------|----------------|
-| CLS Level 3 | 11 | 3 | 4 | 0 | 4 |
+| CLS Level 3 | 11 | 4 | 3 | 0 | 4 |
 | CLS Level 4 | 1 | 0 | 0 | 1 | 0 |
 | JC-STAR additions | 1 | 1 | 0 | 0 | 0 |
 


### PR DESCRIPTION
## Summary

Closes #58. Completes the CLS-02 / STAR-1 R4.1 vulnerability disclosure requirement — previously ⚠️ Partial.

## Changes

- **GitHub settings** — enabled private vulnerability reporting on the repository (reporters use the [Security Advisories](https://github.com/edgesentry/edgesentry-rs/security/advisories/new) form)
- **`README.md`** — added Security section linking to `SECURITY.md` and the private advisory form
- **`docs/src/traceability.md`** — CLS-02 status ⚠️ → ✅; added implementation rows for SECURITY.md and private reporting; CLS Level 3 implemented count 3 → 4
- **`docs/ja/src/traceability.md`** — same updates in Japanese

## Acceptance criteria checklist (from #58)

- [x] `SECURITY.md` added to the repository root (shipped in previous PR)
- [x] GitHub private vulnerability reporting enabled
- [x] Response SLA defined (3 business days ACK; 30/90 days patch)
- [x] Document referenced from README and traceability matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)