### PR TITLE
chore: add keywords, categories, and documentation URL to Cargo.toml

### DIFF
--- a/crates/edgesentry-bridge/Cargo.toml
+++ b/crates/edgesentry-bridge/Cargo.toml
@@ -4,7 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "C/C++ FFI bridge — call Rust signing and verification from C without a full rewrite"
+description   = "C/C++ FFI bridge — call Rust signing and verification from C without a full rewrite"
+keywords      = ["ffi", "cryptography", "ed25519", "blake3", "c-bindings"]
+categories    = ["cryptography", "embedded", "external-ffi-bindings", "authentication"]
+documentation = "https://edgesentry.github.io/edgesentry-rs/ffi_bridge.html"
 
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]

--- a/crates/edgesentry-rs/Cargo.toml
+++ b/crates/edgesentry-rs/Cargo.toml
@@ -4,7 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Tamper-evident immutable audit trace: signing, verification, ingestion and CLI"
+description   = "Tamper-evident immutable audit trace: signing, verification, ingestion and CLI"
+keywords      = ["audit", "cryptography", "ed25519", "blake3", "iot-security"]
+categories    = ["cryptography", "embedded", "network-programming", "authentication"]
+documentation = "https://edgesentry.github.io/edgesentry-rs/"
 
 [[bin]]
 name = "eds"


### PR DESCRIPTION
## Summary

Adds `keywords`, `categories`, and `documentation` to both published crates so they are properly indexed on crates.io.

| Field | edgesentry-rs | edgesentry-bridge |
|-------|--------------|-------------------|
| `keywords` | `audit`, `cryptography`, `ed25519`, `blake3`, `iot-security` | `ffi`, `cryptography`, `ed25519`, `blake3`, `c-bindings` |
| `categories` | `cryptography`, `embedded`, `network-programming`, `authentication` | `cryptography`, `embedded`, `external-ffi-bindings`, `authentication` |
| `documentation` | `https://edgesentry.github.io/edgesentry-rs/` | `https://edgesentry.github.io/edgesentry-rs/ffi_bridge.html` |

All category slugs verified against the [crates.io category list](https://crates.io/category_slugs). Both manifests pass `cargo verify-project`.

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)