### PR TITLE
feat(transport): implement MQTT ingest transport (transport-mqtt feature)

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -38,5 +38,8 @@ jobs:
             pkg:cargo/hashlink,
             pkg:cargo/libsqlite3-sys,
             pkg:cargo/pkg-config,
-            pkg:cargo/vcpkg
+            pkg:cargo/vcpkg,
+            pkg:cargo/rumqttc,
+            pkg:cargo/mqttbytes,
+            pkg:cargo/tokio-rustls
           comment-summary-in-pr: always

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.37",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -782,7 +782,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -802,6 +802,16 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -852,7 +862,7 @@ dependencies = [
  "crc",
  "digest",
  "rustversion",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -1043,10 +1053,11 @@ dependencies = [
  "postgres",
  "rand 0.8.5",
  "reqwest",
+ "rumqttc",
  "rusqlite",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -1150,6 +1161,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
 
 [[package]]
 name = "fnv"
@@ -1524,7 +1546,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "rustls 0.23.37",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1881,6 +1903,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -2242,6 +2270,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rumqttc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
+dependencies = [
+ "bytes",
+ "flume",
+ "futures-util",
+ "log",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile",
+ "rustls-webpki 0.102.8",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls 0.25.0",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,6 +2337,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -2305,14 +2365,36 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2331,6 +2413,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2399,12 +2492,25 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2598,6 +2704,15 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
@@ -2697,11 +2812,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2830,6 +2965,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "tokio",
 ]
 

--- a/crates/edgesentry-rs/Cargo.toml
+++ b/crates/edgesentry-rs/Cargo.toml
@@ -26,7 +26,10 @@ transport-http = [
     "async-ingest",
     "dep:axum",
 ]
-transport-mqtt = []
+transport-mqtt = [
+    "async-ingest",
+    "dep:rumqttc",
+]
 s3 = [
     "dep:aws-config",
     "dep:aws-sdk-s3",
@@ -48,6 +51,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 axum = { version = "0.8", optional = true }
+rumqttc = { version = "0.24", optional = true }
 aws-config = { version = "1", optional = true }
 aws-sdk-s3 = { version = "1", optional = true }
 aws-credential-types = { version = "1", optional = true }

--- a/crates/edgesentry-rs/src/main.rs
+++ b/crates/edgesentry-rs/src/main.rs
@@ -90,6 +90,25 @@ enum Commands {
         #[arg(long = "device", value_name = "ID=PUBKEY_HEX")]
         devices: Vec<String>,
     },
+    #[cfg(feature = "transport-mqtt")]
+    /// Start the MQTT ingest subscriber (requires transport-mqtt feature)
+    ServeMqtt {
+        /// MQTT broker host
+        #[arg(long, default_value = "localhost")]
+        broker: String,
+        /// MQTT broker port
+        #[arg(long, default_value_t = 1883)]
+        port: u16,
+        /// Topic to subscribe to for incoming audit records
+        #[arg(long, default_value = "edgesentry/ingest")]
+        topic: String,
+        /// MQTT client identifier
+        #[arg(long, default_value = "eds-server")]
+        client_id: String,
+        /// Ed25519 public key hex for the device to accept (may be specified multiple times)
+        #[arg(long = "device", value_name = "ID=PUBKEY_HEX")]
+        devices: Vec<String>,
+    },
     #[cfg(all(feature = "s3", feature = "postgres"))]
     /// Ingest records through IngestService into PostgreSQL + MinIO (requires s3,postgres features)
     DemoIngest {
@@ -256,6 +275,40 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             tokio::runtime::Runtime::new()?
                 .block_on(edgesentry_rs::transport::http::serve(service, network_policy, addr))
                 .map_err(|e| format!("server error: {e}"))?;
+        }
+        #[cfg(feature = "transport-mqtt")]
+        Commands::ServeMqtt { broker, port, topic, client_id, devices } => {
+            use ed25519_dalek::VerifyingKey;
+            use edgesentry_rs::{
+                AsyncInMemoryAuditLedger, AsyncInMemoryOperationLog, AsyncInMemoryRawDataStore,
+                AsyncIngestService, IntegrityPolicyGate,
+            };
+            use edgesentry_rs::transport::mqtt::MqttIngestConfig;
+
+            let mut policy = IntegrityPolicyGate::new();
+            for device_spec in &devices {
+                let (device_id, pubkey_hex) = device_spec.split_once('=')
+                    .ok_or_else(|| format!("--device must be ID=PUBKEY_HEX, got: {device_spec}"))?;
+                let key_bytes = parse_fixed_hex::<32>(pubkey_hex)?;
+                let verifying_key = VerifyingKey::from_bytes(&key_bytes)
+                    .map_err(|e| format!("invalid public key for {device_id}: {e}"))?;
+                policy.register_device(device_id, verifying_key);
+            }
+
+            let service = AsyncIngestService::new(
+                policy,
+                AsyncInMemoryRawDataStore::default(),
+                AsyncInMemoryAuditLedger::default(),
+                AsyncInMemoryOperationLog::default(),
+            );
+
+            let config = MqttIngestConfig::new(broker, topic, client_id);
+            let mut config = config;
+            config.broker_port = port;
+
+            tokio::runtime::Runtime::new()?
+                .block_on(edgesentry_rs::transport::mqtt::serve_mqtt(config, service))
+                .map_err(|e| format!("mqtt server error: {e}"))?;
         }
         #[cfg(all(feature = "s3", feature = "postgres"))]
         Commands::DemoIngest {

--- a/crates/edgesentry-rs/src/transport/mqtt.rs
+++ b/crates/edgesentry-rs/src/transport/mqtt.rs
@@ -1,7 +1,61 @@
-//! MQTT ingest transport scaffold.
+//! MQTT ingest transport layer.
 //!
-//! This module reserves the configuration types for a future MQTT-based ingest
-//! transport.  Full protocol implementation is tracked in a separate issue.
+//! Connects to an MQTT broker, subscribes to a configurable topic, and routes
+//! incoming messages through [`AsyncIngestService`].  The message format is the
+//! same JSON envelope used by the HTTP transport:
+//!
+//! ```json
+//! {
+//!   "record": { "device_id": "...", "sequence": 1, ... },
+//!   "raw_payload_hex": "deadbeef..."
+//! }
+//! ```
+//!
+//! Accept / reject outcomes are published on a response topic
+//! `<ingest_topic>/response` as:
+//!
+//! ```json
+//! { "device_id": "...", "sequence": 1, "status": "accepted" }
+//! { "device_id": "...", "sequence": 1, "status": "rejected", "error": "..." }
+//! ```
+//!
+//! # Usage
+//!
+//! ```rust,no_run
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! use edgesentry_rs::transport::mqtt::{MqttIngestConfig, serve_mqtt};
+//! use edgesentry_rs::{
+//!     AsyncInMemoryAuditLedger, AsyncInMemoryOperationLog, AsyncInMemoryRawDataStore,
+//!     AsyncIngestService, IntegrityPolicyGate,
+//! };
+//!
+//! let service = AsyncIngestService::new(
+//!     IntegrityPolicyGate::new(),
+//!     AsyncInMemoryRawDataStore::default(),
+//!     AsyncInMemoryAuditLedger::default(),
+//!     AsyncInMemoryOperationLog::default(),
+//! );
+//!
+//! let config = MqttIngestConfig::new("localhost", "edgesentry/ingest", "eds-server");
+//! serve_mqtt(config, service).await?;
+//! # Ok(())
+//! # }
+//! ```
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tracing::{debug, error, info, warn};
+
+use crate::ingest::{AsyncAuditLedger, AsyncIngestService, AsyncOperationLogStore, AsyncRawDataStore};
+use crate::record::AuditRecord;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
 
 /// Quality-of-service level for MQTT message delivery.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -15,26 +69,38 @@ pub enum MqttQos {
     ExactlyOnce,
 }
 
-/// Configuration for an MQTT ingest endpoint.
-///
-/// Pass this to the (forthcoming) MQTT serve function once the transport is
-/// fully implemented.
+impl From<MqttQos> for QoS {
+    fn from(qos: MqttQos) -> Self {
+        match qos {
+            MqttQos::AtMostOnce => QoS::AtMostOnce,
+            MqttQos::AtLeastOnce => QoS::AtLeastOnce,
+            MqttQos::ExactlyOnce => QoS::ExactlyOnce,
+        }
+    }
+}
+
+/// Configuration for the MQTT ingest transport.
 #[derive(Debug, Clone)]
 pub struct MqttIngestConfig {
     /// MQTT broker host or IP.
     pub broker_host: String,
-    /// MQTT broker port (default 1883, or 8883 for TLS).
+    /// MQTT broker port (default 1883; use 8883 for TLS).
     pub broker_port: u16,
     /// Topic to subscribe to for incoming audit records.
     pub topic: String,
-    /// MQTT client identifier.
+    /// MQTT client identifier — must be unique per broker connection.
     pub client_id: String,
     /// Quality-of-service level for inbound messages.
     pub qos: MqttQos,
+    /// Keep-alive interval sent to the broker.
+    pub keep_alive_secs: u64,
+    /// Capacity of the internal MQTT event channel (number of in-flight messages).
+    pub channel_capacity: usize,
 }
 
 impl MqttIngestConfig {
-    /// Construct a configuration with default port 1883.
+    /// Construct a configuration with default port 1883, QoS AtLeastOnce,
+    /// 30 s keep-alive, and channel capacity 64.
     pub fn new(
         broker_host: impl Into<String>,
         topic: impl Into<String>,
@@ -45,7 +111,299 @@ impl MqttIngestConfig {
             broker_port: 1883,
             topic: topic.into(),
             client_id: client_id.into(),
-            qos: MqttQos::default(),
+            qos: MqttQos::AtLeastOnce,
+            keep_alive_secs: 30,
+            channel_capacity: 64,
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire types
+// ---------------------------------------------------------------------------
+
+/// JSON envelope expected on the ingest topic.
+#[derive(Debug, Deserialize)]
+pub struct MqttIngestRequest {
+    pub record: AuditRecord,
+    pub raw_payload_hex: String,
+}
+
+/// JSON envelope published on the response topic (`<ingest_topic>/response`).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MqttIngestResponse {
+    pub device_id: String,
+    pub sequence: u64,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl MqttIngestResponse {
+    fn accepted(record: &AuditRecord) -> Self {
+        Self {
+            device_id: record.device_id.clone(),
+            sequence: record.sequence,
+            status: "accepted".into(),
+            error: None,
+        }
+    }
+
+    fn rejected(record: &AuditRecord, reason: impl Into<String>) -> Self {
+        Self {
+            device_id: record.device_id.clone(),
+            sequence: record.sequence,
+            status: "rejected".into(),
+            error: Some(reason.into()),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Error)]
+pub enum MqttServeError {
+    #[error("failed to subscribe to topic '{topic}': {reason}")]
+    Subscribe { topic: String, reason: String },
+    #[error("MQTT event loop error: {0}")]
+    EventLoop(String),
+}
+
+// ---------------------------------------------------------------------------
+// Parse helper (testable without a broker)
+// ---------------------------------------------------------------------------
+
+/// Parse raw MQTT message bytes into an [`MqttIngestRequest`].
+///
+/// Exposed so callers can unit-test their message serialisation without a broker.
+pub fn parse_ingest_message(bytes: &[u8]) -> Result<MqttIngestRequest, serde_json::Error> {
+    serde_json::from_slice(bytes)
+}
+
+// ---------------------------------------------------------------------------
+// serve_mqtt
+// ---------------------------------------------------------------------------
+
+/// Connect to the MQTT broker described by `config`, subscribe to the ingest
+/// topic, and route every well-formed message through `service`.
+///
+/// This function runs until the broker connection is lost, at which point it
+/// returns [`MqttServeError::EventLoop`].  Callers that want automatic
+/// reconnection should wrap the call in a retry loop.
+///
+/// Responses (accept / reject) are published on `<topic>/response` at QoS
+/// [`MqttQos::AtMostOnce`] to avoid back-pressure on the event loop.
+pub async fn serve_mqtt<R, L, O>(
+    config: MqttIngestConfig,
+    service: AsyncIngestService<R, L, O>,
+) -> Result<(), MqttServeError>
+where
+    R: AsyncRawDataStore + Send + Sync + 'static,
+    L: AsyncAuditLedger + Send + Sync + 'static,
+    O: AsyncOperationLogStore + Send + Sync + 'static,
+{
+    let mut opts =
+        MqttOptions::new(&config.client_id, &config.broker_host, config.broker_port);
+    opts.set_keep_alive(Duration::from_secs(config.keep_alive_secs));
+
+    let (client, mut eventloop) = AsyncClient::new(opts, config.channel_capacity);
+
+    let qos: QoS = config.qos.into();
+    client
+        .subscribe(&config.topic, qos)
+        .await
+        .map_err(|e| MqttServeError::Subscribe {
+            topic: config.topic.clone(),
+            reason: e.to_string(),
+        })?;
+
+    let response_topic = format!("{}/response", config.topic);
+    let service = Arc::new(service);
+
+    info!(
+        broker = %config.broker_host,
+        port   = config.broker_port,
+        topic  = %config.topic,
+        "MQTT ingest transport started"
+    );
+
+    loop {
+        match eventloop.poll().await {
+            Ok(Event::Incoming(Packet::Publish(publish))) => {
+                debug!(
+                    topic = %publish.topic,
+                    bytes = publish.payload.len(),
+                    "MQTT message received"
+                );
+
+                let svc = Arc::clone(&service);
+                let client2 = client.clone();
+                let resp_topic = response_topic.clone();
+                let payload = publish.payload.to_vec();
+
+                tokio::spawn(async move {
+                    handle_message(&payload, svc, &client2, &resp_topic).await;
+                });
+            }
+            Ok(_) => {
+                // ConnAck, PubAck, SubAck, PingResp, etc. — no action required.
+            }
+            Err(e) => {
+                error!(error = %e, "MQTT event loop error — transport shutting down");
+                return Err(MqttServeError::EventLoop(e.to_string()));
+            }
+        }
+    }
+}
+
+async fn handle_message<R, L, O>(
+    bytes: &[u8],
+    service: Arc<AsyncIngestService<R, L, O>>,
+    client: &AsyncClient,
+    response_topic: &str,
+) where
+    R: AsyncRawDataStore + Send + Sync + 'static,
+    L: AsyncAuditLedger + Send + Sync + 'static,
+    O: AsyncOperationLogStore + Send + Sync + 'static,
+{
+    let req = match parse_ingest_message(bytes) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(error = %e, "MQTT message is not valid JSON — discarded");
+            return;
+        }
+    };
+
+    let raw_payload = match hex::decode(&req.raw_payload_hex) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(error = %e, "raw_payload_hex is not valid hex — discarded");
+            return;
+        }
+    };
+
+    let response = match service.ingest(req.record.clone(), &raw_payload, None).await {
+        Ok(()) => {
+            info!(
+                device_id = %req.record.device_id,
+                sequence  = req.record.sequence,
+                "MQTT record accepted"
+            );
+            MqttIngestResponse::accepted(&req.record)
+        }
+        Err(e) => {
+            warn!(
+                device_id = %req.record.device_id,
+                sequence  = req.record.sequence,
+                reason    = %e,
+                "MQTT record rejected"
+            );
+            MqttIngestResponse::rejected(&req.record, e.to_string())
+        }
+    };
+
+    if let Ok(json) = serde_json::to_vec(&response) {
+        // Best-effort publish — if it fails, log and continue.
+        if let Err(e) = client.publish(response_topic, QoS::AtMostOnce, false, json).await {
+            warn!(error = %e, "failed to publish MQTT response");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests (no broker required)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{build_signed_record, parse_fixed_hex, record::AuditRecord};
+    use ed25519_dalek::SigningKey;
+
+    const PRIV_HEX: &str = "0101010101010101010101010101010101010101010101010101010101010101";
+
+    fn make_record() -> (AuditRecord, Vec<u8>) {
+        let key_bytes = parse_fixed_hex::<32>(PRIV_HEX).unwrap();
+        let signing_key = SigningKey::from_bytes(&key_bytes);
+        let payload = b"scenario=lift-inspection,check=door".to_vec();
+        let record = build_signed_record(
+            "lift-01".to_string(),
+            1,
+            1_700_000_000_000,
+            &payload,
+            AuditRecord::zero_hash(),
+            "s3://bucket/lift-01/1.bin".to_string(),
+            &signing_key,
+        );
+        (record, payload)
+    }
+
+    #[test]
+    fn mqtt_qos_converts_correctly() {
+        assert_eq!(QoS::from(MqttQos::AtMostOnce), QoS::AtMostOnce);
+        assert_eq!(QoS::from(MqttQos::AtLeastOnce), QoS::AtLeastOnce);
+        assert_eq!(QoS::from(MqttQos::ExactlyOnce), QoS::ExactlyOnce);
+    }
+
+    #[test]
+    fn config_defaults_are_sensible() {
+        let cfg = MqttIngestConfig::new("broker.local", "edgesentry/ingest", "eds-1");
+        assert_eq!(cfg.broker_port, 1883);
+        assert_eq!(cfg.qos, MqttQos::AtLeastOnce);
+        assert_eq!(cfg.keep_alive_secs, 30);
+        assert_eq!(cfg.channel_capacity, 64);
+    }
+
+    #[test]
+    fn parse_ingest_message_accepts_valid_json() {
+        let (record, payload) = make_record();
+        let json = serde_json::to_vec(&serde_json::json!({
+            "record": record,
+            "raw_payload_hex": hex::encode(&payload),
+        }))
+        .unwrap();
+
+        let parsed = parse_ingest_message(&json).unwrap();
+        assert_eq!(parsed.record.device_id, record.device_id);
+        assert_eq!(parsed.record.sequence, record.sequence);
+        assert_eq!(parsed.raw_payload_hex, hex::encode(&payload));
+    }
+
+    #[test]
+    fn parse_ingest_message_rejects_malformed_json() {
+        assert!(parse_ingest_message(b"not json at all").is_err());
+    }
+
+    #[test]
+    fn parse_ingest_message_rejects_missing_fields() {
+        assert!(parse_ingest_message(b"{\"record\": null}").is_err());
+    }
+
+    #[test]
+    fn response_accepted_fields() {
+        let (record, _) = make_record();
+        let resp = MqttIngestResponse::accepted(&record);
+        assert_eq!(resp.status, "accepted");
+        assert_eq!(resp.device_id, record.device_id);
+        assert_eq!(resp.sequence, record.sequence);
+        assert!(resp.error.is_none());
+    }
+
+    #[test]
+    fn response_rejected_fields() {
+        let (record, _) = make_record();
+        let resp = MqttIngestResponse::rejected(&record, "unknown device");
+        assert_eq!(resp.status, "rejected");
+        assert_eq!(resp.error.as_deref(), Some("unknown device"));
+    }
+
+    #[test]
+    fn response_accepted_serialises_without_error_field() {
+        let (record, _) = make_record();
+        let resp = MqttIngestResponse::accepted(&record);
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(!json.contains("\"error\""), "accepted response must not include 'error' key");
     }
 }

--- a/crates/edgesentry-rs/tests/integration.rs
+++ b/crates/edgesentry-rs/tests/integration.rs
@@ -10,3 +10,5 @@ mod async_ingest_integration;
 mod http_integration;
 #[path = "integration/buffer_integration.rs"]
 mod buffer_integration;
+#[path = "integration/mqtt_integration.rs"]
+mod mqtt_integration;

--- a/crates/edgesentry-rs/tests/integration/mqtt_integration.rs
+++ b/crates/edgesentry-rs/tests/integration/mqtt_integration.rs
@@ -1,0 +1,216 @@
+//! MQTT transport integration tests.
+//!
+//! Tests that do not require a broker exercise the message parsing and response
+//! serialisation logic directly.
+//!
+//! Broker-level round-trip tests require a running MQTT broker and are gated
+//! behind the `TEST_MQTT_BROKER` environment variable (e.g. `mosquitto` on
+//! localhost:1883).  They are skipped automatically in CI unless the variable
+//! is set.
+
+#![cfg(feature = "transport-mqtt")]
+
+use edgesentry_rs::{
+    build_lift_inspection_demo_records_with_payloads, parse_fixed_hex,
+    transport::mqtt::{
+        parse_ingest_message, MqttIngestConfig, MqttIngestRequest, MqttIngestResponse, MqttQos,
+    },
+    AuditRecord,
+};
+use ed25519_dalek::SigningKey;
+
+const PRIV_HEX: &str = "0101010101010101010101010101010101010101010101010101010101010101";
+
+fn demo_pairs() -> Vec<(AuditRecord, Vec<u8>)> {
+    build_lift_inspection_demo_records_with_payloads(
+        "lift-01",
+        PRIV_HEX,
+        1_700_000_000_000,
+        "s3://bucket/lift-01",
+    )
+    .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Message parsing — no broker required
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_valid_ingest_message() {
+    let pairs = demo_pairs();
+    let (record, payload) = &pairs[0];
+
+    let json = serde_json::json!({
+        "record": record,
+        "raw_payload_hex": hex::encode(payload),
+    })
+    .to_string();
+
+    let req: MqttIngestRequest = parse_ingest_message(json.as_bytes()).unwrap();
+    assert_eq!(req.record.device_id, record.device_id);
+    assert_eq!(req.record.sequence, record.sequence);
+}
+
+#[test]
+fn parse_rejects_empty_bytes() {
+    assert!(parse_ingest_message(b"").is_err());
+}
+
+#[test]
+fn parse_rejects_garbage() {
+    assert!(parse_ingest_message(b"\x00\x01\x02").is_err());
+}
+
+#[test]
+fn parse_rejects_json_missing_record_field() {
+    assert!(parse_ingest_message(b"{\"raw_payload_hex\": \"deadbeef\"}").is_err());
+}
+
+#[test]
+fn parse_rejects_json_missing_payload_field() {
+    let pairs = demo_pairs();
+    let json = serde_json::json!({ "record": pairs[0].0 }).to_string();
+    assert!(parse_ingest_message(json.as_bytes()).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Config defaults
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_new_sets_sensible_defaults() {
+    let cfg = MqttIngestConfig::new("10.0.0.1", "edgesentry/ingest", "eds-test");
+    assert_eq!(cfg.broker_host, "10.0.0.1");
+    assert_eq!(cfg.broker_port, 1883);
+    assert_eq!(cfg.topic, "edgesentry/ingest");
+    assert_eq!(cfg.client_id, "eds-test");
+    assert_eq!(cfg.qos, MqttQos::AtLeastOnce);
+    assert_eq!(cfg.keep_alive_secs, 30);
+    assert_eq!(cfg.channel_capacity, 64);
+}
+
+// ---------------------------------------------------------------------------
+// Response serialisation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accepted_response_roundtrip() {
+    let pairs = demo_pairs();
+    let record = &pairs[0].0;
+    let resp = MqttIngestResponse {
+        device_id: record.device_id.clone(),
+        sequence: record.sequence,
+        status: "accepted".into(),
+        error: None,
+    };
+    let json = serde_json::to_string(&resp).unwrap();
+    assert!(json.contains("\"accepted\""));
+    assert!(!json.contains("\"error\""), "accepted response must omit 'error' key");
+}
+
+#[test]
+fn rejected_response_contains_error() {
+    let pairs = demo_pairs();
+    let record = &pairs[0].0;
+    let resp = MqttIngestResponse {
+        device_id: record.device_id.clone(),
+        sequence: record.sequence,
+        status: "rejected".into(),
+        error: Some("unknown device".into()),
+    };
+    let json = serde_json::to_string(&resp).unwrap();
+    assert!(json.contains("\"rejected\""));
+    assert!(json.contains("\"unknown device\""));
+}
+
+// ---------------------------------------------------------------------------
+// Broker round-trip — requires TEST_MQTT_BROKER env var
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires a running MQTT broker — set TEST_MQTT_BROKER=host:port to enable"]
+async fn broker_roundtrip_accepts_valid_record() {
+    use edgesentry_rs::{
+        AsyncInMemoryAuditLedger, AsyncInMemoryOperationLog, AsyncInMemoryRawDataStore,
+        AsyncIngestService, IntegrityPolicyGate,
+    };
+    use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS};
+    use std::time::Duration;
+
+    let broker_addr = std::env::var("TEST_MQTT_BROKER")
+        .unwrap_or_else(|_| "localhost:1883".to_string());
+    let (host, port_str) = broker_addr.split_once(':').unwrap_or((&broker_addr, "1883"));
+    let port: u16 = port_str.parse().unwrap_or(1883);
+
+    // Register device
+    let key_bytes = parse_fixed_hex::<32>(PRIV_HEX).unwrap();
+    let signing_key = SigningKey::from_bytes(&key_bytes);
+    let mut policy = IntegrityPolicyGate::new();
+    policy.register_device("lift-01", signing_key.verifying_key());
+
+    let service = AsyncIngestService::new(
+        policy,
+        AsyncInMemoryRawDataStore::default(),
+        AsyncInMemoryAuditLedger::default(),
+        AsyncInMemoryOperationLog::default(),
+    );
+
+    let ingest_topic = "edgesentry/ingest/test-broker-roundtrip";
+    let response_topic = format!("{ingest_topic}/response");
+
+    // Start serve_mqtt in a background task
+    let cfg = {
+        let mut c = MqttIngestConfig::new(host, ingest_topic, "eds-server-test");
+        c.broker_port = port;
+        c
+    };
+    let serve_handle = tokio::spawn(async move {
+        let _ = edgesentry_rs::transport::mqtt::serve_mqtt(cfg, service).await;
+    });
+
+    // Give the server time to connect and subscribe
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Publish client — uses a different client_id
+    let mut opts = MqttOptions::new("eds-test-publisher", host, port);
+    opts.set_keep_alive(Duration::from_secs(10));
+    let (pub_client, mut pub_eventloop) = AsyncClient::new(opts, 16);
+
+    // Subscribe to the response topic before publishing
+    pub_client.subscribe(&response_topic, QoS::AtLeastOnce).await.unwrap();
+
+    // Build and publish a valid record
+    let pairs = demo_pairs();
+    let (record, payload) = &pairs[0];
+    let msg = serde_json::json!({
+        "record": record,
+        "raw_payload_hex": hex::encode(payload),
+    })
+    .to_string();
+    pub_client
+        .publish(ingest_topic, QoS::AtLeastOnce, false, msg.as_bytes())
+        .await
+        .unwrap();
+
+    // Drain events and wait for the response
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if tokio::time::Instant::now() > deadline {
+            panic!("timed out waiting for MQTT response");
+        }
+        match pub_eventloop.poll().await {
+            Ok(Event::Incoming(Packet::Publish(p))) if p.topic == response_topic => {
+                let resp: MqttIngestResponse =
+                    serde_json::from_slice(&p.payload).expect("valid response JSON");
+                assert_eq!(resp.status, "accepted");
+                assert_eq!(resp.device_id, record.device_id);
+                assert_eq!(resp.sequence, record.sequence);
+                break;
+            }
+            Ok(_) => {}
+            Err(e) => panic!("publisher event loop error: {e}"),
+        }
+    }
+
+    serve_handle.abort();
+}


### PR DESCRIPTION
Closes #146

## Summary

- Replaces the `mqtt.rs` config-only scaffold with a full `serve_mqtt` implementation backed by `rumqttc`
- Same JSON envelope as the HTTP transport — devices already publishing to HTTP can switch to MQTT with no schema change
- Accept/reject decisions published on `<topic>/response` so edge devices get confirmation without polling
- `eds serve-mqtt` CLI subcommand mirrors `eds serve` with broker-specific flags
- Broker round-trip integration test is `#[ignore]`-gated on `TEST_MQTT_BROKER` env var to keep CI dependency-free

## Key design decisions

| Decision | Rationale |
|----------|-----------|
| `rumqttc` async client | Pure Rust, tokio-native, widely used in IoT crates |
| One spawned task per message | Prevents slow ingest from blocking the event loop |
| `parse_ingest_message` as a public helper | Lets callers unit-test serialisation without a broker |
| Response at QoS 0 (AtMostOnce) | Avoids back-pressure on the MQTT event loop for fire-and-forget ACKs |

## Test plan

- [x] `cargo build --features transport-mqtt` — clean build
- [x] 8 unit tests: QoS conversion, config defaults, parse happy/sad paths, response shape
- [x] 8 no-broker integration tests: parse edge cases, config, response serialisation
- [x] 1 `#[ignore]` broker round-trip test (run with `TEST_MQTT_BROKER=localhost:1883`)
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)