### PR TITLE
test: add unit tests for verify_chain_file, write_record_json, write_records_json

### DIFF
--- a/crates/edgesentry-rs/tests/unit/core_tests.rs
+++ b/crates/edgesentry-rs/tests/unit/core_tests.rs
@@ -1,8 +1,10 @@
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use edgesentry_rs::{
-    compute_payload_hash, sign_payload_hash, verify_chain, verify_payload_signature, AuditRecord,
+    build_lift_inspection_demo_records, compute_payload_hash, sign_payload_hash, verify_chain,
+    verify_chain_file, verify_payload_signature, write_record_json, write_records_json, AuditRecord,
     ChainError,
 };
+use std::{fs, path::PathBuf};
 
 fn dummy_record(sequence: u64, prev_record_hash: [u8; 32]) -> AuditRecord {
     AuditRecord {
@@ -101,4 +103,96 @@ fn verify_payload_signature_rejects_wrong_key() {
     let sig = sign_payload_hash(&signing_key, &payload_hash);
 
     assert!(!verify_payload_signature(&wrong_key, &payload_hash, &sig));
+}
+
+// Helper: unique temp path that is cleaned up on drop via a guard
+fn tmp_path(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("edgesentry_test_{}_{name}", std::process::id()));
+    p
+}
+
+struct TmpFile(PathBuf);
+impl Drop for TmpFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+#[test]
+fn write_records_json_roundtrips_through_verify_chain_file() {
+    // Build a small valid chain via the public demo helper
+    let keypair = edgesentry_rs::generate_keypair();
+    let records =
+        build_lift_inspection_demo_records("lift-01", &keypair.private_key_hex, 1_710_000_000_000, "s3://b")
+            .expect("demo records");
+
+    let path = tmp_path("write_records_json.json");
+    let _guard = TmpFile(path.clone());
+
+    // write_records_json serialises the slice to a JSON file
+    write_records_json(&path, &records).expect("write_records_json");
+    assert!(path.exists());
+
+    // verify_chain_file deserialises and verifies the chain
+    verify_chain_file(&path).expect("verify_chain_file");
+}
+
+#[test]
+fn verify_chain_file_rejects_tampered_json() {
+    let keypair = edgesentry_rs::generate_keypair();
+    let mut records =
+        build_lift_inspection_demo_records("lift-01", &keypair.private_key_hex, 1_710_000_000_000, "s3://b")
+            .expect("demo records");
+
+    // Tamper with the second record's payload hash to break the chain link
+    records[1].payload_hash[0] ^= 0xFF;
+
+    let path = tmp_path("verify_chain_file_tampered.json");
+    let _guard = TmpFile(path.clone());
+
+    write_records_json(&path, &records).expect("write");
+    let result = verify_chain_file(&path);
+    assert!(result.is_err(), "tampered chain should be rejected");
+}
+
+#[test]
+fn verify_chain_file_rejects_malformed_json() {
+    let path = tmp_path("verify_chain_file_malformed.json");
+    let _guard = TmpFile(path.clone());
+
+    fs::write(&path, b"not valid json at all").expect("write");
+    let result = verify_chain_file(&path);
+    assert!(result.is_err(), "malformed JSON should be rejected");
+}
+
+#[test]
+fn write_record_json_to_file_roundtrips() {
+    let keypair = edgesentry_rs::generate_keypair();
+    let records =
+        build_lift_inspection_demo_records("lift-01", &keypair.private_key_hex, 1_710_000_000_000, "s3://b")
+            .expect("demo records");
+    let record = &records[0];
+
+    let path = tmp_path("write_record_json.json");
+    let _guard = TmpFile(path.clone());
+
+    write_record_json(Some(&path), record).expect("write_record_json");
+
+    let content = fs::read_to_string(&path).expect("read back");
+    let decoded: AuditRecord = serde_json::from_str(&content).expect("deserialise");
+    assert_eq!(decoded.device_id, record.device_id);
+    assert_eq!(decoded.sequence, record.sequence);
+    assert_eq!(decoded.payload_hash, record.payload_hash);
+}
+
+#[test]
+fn write_record_json_stdout_path_is_none() {
+    // Passing None should print to stdout without error (no file created)
+    let keypair = edgesentry_rs::generate_keypair();
+    let records =
+        build_lift_inspection_demo_records("lift-01", &keypair.private_key_hex, 1_710_000_000_000, "s3://b")
+            .expect("demo records");
+    // Should not panic or error
+    write_record_json(None, &records[0]).expect("write_record_json stdout");
 }


### PR DESCRIPTION
## Summary

Adds 5 unit tests to `tests/unit/core_tests.rs` covering the three public CLI helpers in `lib.rs` that had no automated test coverage:

| Function | Tests added |
|----------|-------------|
| `verify_chain_file` | roundtrip with valid chain, tampered chain rejected, malformed JSON rejected |
| `write_records_json` | roundtrip (write → verify_chain_file) |
| `write_record_json` | file roundtrip with field assertion, `None` path (stdout) does not panic |

All tests use only `std` (temp dir via `std::env::temp_dir()`, scoped cleanup via a drop guard) — no new dev-dependencies added.

## Test plan

- [ ] `cargo test --package edgesentry-rs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)