### PR TITLE
fix(ci): install cargo-llvm-cov via cargo install, not taiki-e action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        run: cargo llvm-cov --version 2>/dev/null || cargo install cargo-llvm-cov --locked
 
       - name: Generate coverage report
         # Exclude external-service tests (Postgres, S3, MQTT broker) via --exclude-from-test.


### PR DESCRIPTION
## Problem

`taiki-e/install-action@cargo-llvm-cov` uses a non-semver tag ref that causes `startup_failure` (0s run, "workflow file issue") in GitHub Actions. Every CI run on PR #162 failed with this error.

## Fix

Replace:
```yaml
- name: Install cargo-llvm-cov
  uses: taiki-e/install-action@cargo-llvm-cov
```

With:
```yaml
- name: Install cargo-llvm-cov
  run: cargo llvm-cov --version 2>/dev/null || cargo install cargo-llvm-cov --locked
```

This matches the existing pattern used for `cargo-deny` and `cargo-audit` in the same CI file. No new external action dependency is introduced.

## Test plan

- [ ] `coverage` job starts (no more `startup_failure`)
- [ ] `coverage` job completes successfully and uploads `lcov.info` artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)