### PR TITLE
docs: update architecture.md MQTT section to reflect functional implementation

### DIFF
--- a/docs/ja/src/architecture.md
+++ b/docs/ja/src/architecture.md
@@ -49,3 +49,149 @@
 6. いずれかのチェックが失敗した場合、インジェストは拒否される。すべてのチェックが通過した場合、レコードは受け入れられる。
 
 要約すると、エッジはファクトに署名し、クラウドが連続性と真正性を強制します。
+
+## インジェストサービス：同期・非同期パス
+
+`edgesentry-rs` はフィーチャーフラグで選択できるクラウド側インジェスト用オーケストレーションサービスを 2 種類提供します。
+
+| 型 | フィーチャーフラグ | スレッドモデル | 用途 |
+|------|-------------|-------------|--------------|
+| `IngestService` | *（常に利用可能）* | ブロッキング / 同期 | 組み込み・CLI ツール・組み込みランタイム |
+| `AsyncIngestService` | `async-ingest` | `async/await`（tokio）| HTTP サーバー・非同期パイプライン |
+
+### 同期パス（`IngestService`）
+
+同期サービスはデフォルトであり、追加フィーチャーは不要です。S3 書き込み（`s3` フィーチャーが有効な場合）は組み込みの `tokio::runtime::Runtime` 内で `block_on` して実行されます。シングルスレッドツールや組み込み環境に適しています。
+
+```rust
+let mut svc = IngestService::new(policy, raw_store, ledger, op_log);
+svc.register_device("lift-01", verifying_key);
+svc.ingest(record, payload, None)?;
+```
+
+### 非同期パス（`AsyncIngestService`）
+
+`features = ["async-ingest"]` で有効化します。すべてのストレージ呼び出しが `.await` を使用するため、呼び出しスレッドがブロックされず、高並行パイプラインを実現します。ポリシーゲートは `tokio::sync::Mutex` でラップされているため、`Arc` 経由でタスク間で共有できます。
+
+```rust
+let svc = Arc::new(AsyncIngestService::new(policy, raw_store, ledger, op_log));
+svc.register_device("lift-01", verifying_key).await;
+svc.ingest(record, payload, None).await?;
+```
+
+`s3` と `async-ingest` が両方有効な場合、`S3CompatibleRawDataStore` は AWS SDK フューチャーを直接呼び出して `AsyncRawDataStore` を実装します。組み込みランタイムは不要です。
+
+### フィーチャーフラグ一覧
+
+| フラグ | 追加されるもの |
+|------|-------------|
+| `async-ingest` | `AsyncRawDataStore`・`AsyncAuditLedger`・`AsyncOperationLogStore` トレイト；`AsyncIngestService`；インメモリ非同期ストア；`tokio`（sync + macros）|
+| `s3` | `S3CompatibleRawDataStore`（同期）；`async-ingest` と組み合わせると `AsyncRawDataStore` も実装 |
+| `postgres` | `PostgresAuditLedger`・`PostgresOperationLog`（同期）|
+| `transport-http` | `transport::http::serve()` — axum ベースの `POST /api/v1/ingest` サーバー；`eds serve` CLI サブコマンド |
+| `transport-mqtt` | `transport::mqtt::serve_mqtt()` — 非同期 rumqttc イベントループ；トピックをサブスクライブし、レコードを `AsyncIngestService` にルーティングし、承認/拒否レスポンスを発行 |
+
+## トランスポート層
+
+`transport` モジュールは `AsyncIngestService` の上に構築されたネットワーク向けインジェストエンドポイントを提供します。
+
+### HTTP（`transport-http` フィーチャー）
+
+`features = ["transport-http"]` で有効化します。`axum 0.8` を取り込み、単一の `POST /api/v1/ingest` エンドポイントを公開します。
+
+#### リクエスト / レスポンス
+
+| フィールド | 型 | 説明 |
+|-------|------|-------------|
+| `record` | `AuditRecord`（JSON）| デバイスからの署名済み監査レコード |
+| `raw_payload_hex` | `String` | 16 進数エンコードされた生ペイロードバイト |
+
+| ステータス | 意味 |
+|--------|---------|
+| `202 Accepted` | レコードがすべてのチェックを通過し、保存された |
+| `400 Bad Request` | `raw_payload_hex` が有効な 16 進数でない |
+| `403 Forbidden` | クライアント IP が `NetworkPolicy` の許可リストにない |
+| `422 Unprocessable Entity` | レコードの署名・ハッシュ・チェーン検証に失敗した |
+
+#### 使用例
+
+```rust
+use edgesentry_rs::{
+    AsyncIngestService, AsyncInMemoryRawDataStore, AsyncInMemoryAuditLedger,
+    AsyncInMemoryOperationLog, IntegrityPolicyGate, NetworkPolicy,
+};
+use edgesentry_rs::transport::http::serve;
+
+let mut policy = IntegrityPolicyGate::new();
+policy.register_device("lift-01", verifying_key);
+
+let mut network_policy = NetworkPolicy::new();
+network_policy.allow_cidr("10.0.0.0/8").unwrap();
+
+let service = AsyncIngestService::new(
+    policy,
+    AsyncInMemoryRawDataStore::default(),
+    AsyncInMemoryAuditLedger::default(),
+    AsyncInMemoryOperationLog::default(),
+);
+
+let addr = "0.0.0.0:8080".parse().unwrap();
+serve(service, network_policy, addr).await?;
+```
+
+#### CLI
+
+```sh
+eds serve \
+  --addr 0.0.0.0:8080 \
+  --allowed-sources 10.0.0.0/8,127.0.0.1 \
+  --device lift-01=<pubkey_hex>
+```
+
+### MQTT（`transport-mqtt` フィーチャー）
+
+`features = ["transport-mqtt"]` で有効化します。`rumqttc` を取り込み、`serve_mqtt()` を公開します。`serve_mqtt()` は MQTT ブローカーに接続し、設定可能なインジェストトピックをサブスクライブし、受信メッセージを `AsyncIngestService` にルーティングする完全非同期イベントループです。
+
+メッセージ形式は HTTP トランスポートと同じ JSON エンベロープです：
+
+```json
+{ "record": { "device_id": "...", "sequence": 1, ... }, "raw_payload_hex": "deadbeef..." }
+```
+
+承認/拒否の結果は `<topic>/response` に発行されます：
+
+```json
+{ "device_id": "...", "sequence": 1, "status": "accepted" }
+{ "device_id": "...", "sequence": 1, "status": "rejected", "error": "..." }
+```
+
+#### 使用例
+
+```rust
+use edgesentry_rs::transport::mqtt::{MqttIngestConfig, serve_mqtt};
+use edgesentry_rs::{
+    AsyncIngestService, AsyncInMemoryRawDataStore, AsyncInMemoryAuditLedger,
+    AsyncInMemoryOperationLog, IntegrityPolicyGate,
+};
+
+let service = AsyncIngestService::new(
+    IntegrityPolicyGate::new(),
+    AsyncInMemoryRawDataStore::default(),
+    AsyncInMemoryAuditLedger::default(),
+    AsyncInMemoryOperationLog::default(),
+);
+
+let config = MqttIngestConfig::new("mqtt.example.com", "devices/+/ingest", "edgesentry-cloud");
+serve_mqtt(config, service).await?;
+```
+
+`serve_mqtt` はブローカー接続が切断されるまで実行し、`MqttServeError::EventLoop` を返します。自動再接続にはリトライループでラップしてください。
+
+#### 主な動作
+
+| 動作 | 詳細 |
+|-----------|--------|
+| 不正な JSON | メッセージはログに記録され破棄される；イベントループは継続する |
+| 無効な 16 進数ペイロード | メッセージはログに記録され破棄される；イベントループは継続する |
+| インジェスト拒否 | `"status": "rejected"` を含むレスポンスを `<topic>/response` に発行する |
+| レスポンス発行失敗 | 警告としてログに記録される；イベントループは停止しない |

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -89,7 +89,7 @@ When `s3` and `async-ingest` are both active, `S3CompatibleRawDataStore` impleme
 | `s3` | `S3CompatibleRawDataStore` (sync); when combined with `async-ingest`, also implements `AsyncRawDataStore` |
 | `postgres` | `PostgresAuditLedger`, `PostgresOperationLog` (sync) |
 | `transport-http` | `transport::http::serve()` — axum-based `POST /api/v1/ingest` server; `eds serve` CLI subcommand |
-| `transport-mqtt` | `transport::mqtt::MqttIngestConfig` scaffold (full implementation pending) |
+| `transport-mqtt` | `transport::mqtt::serve_mqtt()` — async rumqttc event loop; subscribes to a topic, routes records through `AsyncIngestService`, publishes accept/reject responses |
 
 ## Transport Layer
 
@@ -150,16 +150,48 @@ eds serve \
 
 ### MQTT (`transport-mqtt` feature)
 
-The `transport-mqtt` feature currently provides `MqttIngestConfig` — a configuration struct describing the broker, topic, client ID, and QoS level.  Full protocol implementation is planned in a follow-up issue.
+Enable with `features = ["transport-mqtt"]`.  This brings in `rumqttc` and exposes `serve_mqtt()` — a fully async event loop that connects to an MQTT broker, subscribes to a configurable ingest topic, and routes every incoming message through `AsyncIngestService`.
+
+The message format is the same JSON envelope used by the HTTP transport:
+
+```json
+{ "record": { "device_id": "...", "sequence": 1, ... }, "raw_payload_hex": "deadbeef..." }
+```
+
+Accept / reject outcomes are published on `<topic>/response`:
+
+```json
+{ "device_id": "...", "sequence": 1, "status": "accepted" }
+{ "device_id": "...", "sequence": 1, "status": "rejected", "error": "..." }
+```
+
+#### Usage
 
 ```rust
-use edgesentry_rs::transport::mqtt::{MqttIngestConfig, MqttQos};
-
-let config = MqttIngestConfig {
-    broker_host: "mqtt.example.com".into(),
-    broker_port: 1883,
-    topic: "devices/+/ingest".into(),
-    client_id: "edgesentry-cloud".into(),
-    qos: MqttQos::AtLeastOnce,
+use edgesentry_rs::transport::mqtt::{MqttIngestConfig, serve_mqtt};
+use edgesentry_rs::{
+    AsyncIngestService, AsyncInMemoryRawDataStore, AsyncInMemoryAuditLedger,
+    AsyncInMemoryOperationLog, IntegrityPolicyGate,
 };
+
+let service = AsyncIngestService::new(
+    IntegrityPolicyGate::new(),
+    AsyncInMemoryRawDataStore::default(),
+    AsyncInMemoryAuditLedger::default(),
+    AsyncInMemoryOperationLog::default(),
+);
+
+let config = MqttIngestConfig::new("mqtt.example.com", "devices/+/ingest", "edgesentry-cloud");
+serve_mqtt(config, service).await?;
 ```
+
+`serve_mqtt` runs until the broker connection is lost, returning `MqttServeError::EventLoop`.  Wrap the call in a retry loop for automatic reconnection.
+
+#### Key behaviors
+
+| Behavior | Detail |
+|-----------|--------|
+| Malformed JSON | Message is logged and discarded; event loop continues |
+| Invalid hex payload | Message is logged and discarded; event loop continues |
+| Ingest rejection | Response published on `<topic>/response` with `"status": "rejected"` |
+| Response publish failure | Logged as a warning; does not stop the event loop |


### PR DESCRIPTION
## Summary

The `transport-mqtt` feature has been fully implemented since #146, but `architecture.md` (English and Japanese) still described it as an unfinished scaffold. This PR brings the docs in sync with the code.

## Changes

### `docs/src/architecture.md`

- **Feature flag table**: replaces `"MqttIngestConfig scaffold (full implementation pending)"` with an accurate description of `serve_mqtt()` and its behavior
- **MQTT section**: replaces the stub config-only code example with full prose covering:
  - The async `rumqttc` event loop
  - JSON envelope format (same as HTTP transport)
  - Response topic (`<topic>/response`) with accept/reject examples
  - Real `serve_mqtt()` usage example
  - Reconnection guidance
  - Key behaviors table (malformed JSON, invalid hex, ingest rejection, publish failure)

### `docs/ja/src/architecture.md`

- Adds the entire missing **Ingest Service**, **feature flag summary**, and **Transport Layer** sections (HTTP + MQTT) that existed in the English doc but were absent from the Japanese translation
- MQTT section reflects the functional implementation throughout

## Test plan

- [x] English and Japanese docs reviewed for accuracy against `src/transport/mqtt.rs`
- [x] Code examples verified against the actual public API (`serve_mqtt`, `MqttIngestConfig::new`)

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)