### PR TITLE
fix: move lang-switcher link left to clear nav-chapters button

### DIFF
--- a/docs/ja/src/theme/lang-switcher.js
+++ b/docs/ja/src/theme/lang-switcher.js
@@ -1,6 +1,6 @@
 (function () {
   var bar = document.createElement('div');
-  bar.style.cssText = 'background:#f0f4ff;border-bottom:1px solid #c8d8ff;padding:6px 16px;font-size:0.85em;text-align:right;';
+  bar.style.cssText = 'background:#f0f4ff;border-bottom:1px solid #c8d8ff;padding:6px 16px;font-size:0.85em;text-align:left;';
   bar.innerHTML = '🌐 <a href="/edgesentry-rs/en/" style="color:#3a7bd5;text-decoration:none;">English</a>';
   var content = document.querySelector('.content');
   if (content) content.prepend(bar);

--- a/docs/ja/theme/lang-switcher.js
+++ b/docs/ja/theme/lang-switcher.js
@@ -4,7 +4,7 @@
     ? window.location.href.replace(/localhost:\d+/, 'localhost:3000')
     : '/edgesentry-rs/en/';
   var bar = document.createElement('div');
-  bar.style.cssText = 'background:#f0f4ff;border-bottom:1px solid #c8d8ff;padding:6px 16px;font-size:0.85em;text-align:right;';
+  bar.style.cssText = 'background:#f0f4ff;border-bottom:1px solid #c8d8ff;padding:6px 16px;font-size:0.85em;text-align:left;';
   bar.innerHTML = '🌐 <a href="' + enUrl + '" style="color:#3a7bd5;text-decoration:none;">English</a>';
   var content = document.querySelector('.content');
   if (content) content.prepend(bar);

--- a/docs/src/theme/lang-switcher.js
+++ b/docs/src/theme/lang-switcher.js
@@ -1,6 +1,6 @@
 (function () {
   var bar = document.createElement('div');
-  bar.style.cssText = 'background:#f0f4ff;border-bottom:1px solid #c8d8ff;padding:6px 16px;font-size:0.85em;text-align:right;';
+  bar.style.cssText = 'background:#f0f4ff;border-bottom:1px solid #c8d8ff;padding:6px 16px;font-size:0.85em;text-align:left;';
   bar.innerHTML = '🌐 <a href="/edgesentry-rs/ja/" style="color:#3a7bd5;text-decoration:none;">日本語版</a>';
   var content = document.querySelector('.content');
   if (content) content.prepend(bar);

--- a/docs/theme/lang-switcher.js
+++ b/docs/theme/lang-switcher.js
@@ -4,7 +4,7 @@
     ? window.location.href.replace(/localhost:\d+/, 'localhost:3001')
     : '/edgesentry-rs/ja/';
   var bar = document.createElement('div');
-  bar.style.cssText = 'background:#f0f4ff;border-bottom:1px solid #c8d8ff;padding:6px 16px;font-size:0.85em;text-align:right;';
+  bar.style.cssText = 'background:#f0f4ff;border-bottom:1px solid #c8d8ff;padding:6px 16px;font-size:0.85em;text-align:left;';
   bar.innerHTML = '🌐 <a href="' + jaUrl + '" style="color:#3a7bd5;text-decoration:none;">日本語版</a>';
   var content = document.querySelector('.content');
   if (content) content.prepend(bar);


### PR DESCRIPTION
## Summary

- `docs/theme/lang-switcher.js` and all three sibling copies used `text-align:right`, positioning the translation link at the right edge of the content area
- mdBook's `.nav-chapters` element (`position:fixed; top:0; bottom:0; min-width:90px`) is a full-height column anchored to the right of the viewport — it sits on top of the link and intercepts all clicks
- Fix: change `text-align:right` → `text-align:left` so the link renders at the left of the bar, well clear of the fixed nav column

## Files changed

- `docs/theme/lang-switcher.js`
- `docs/ja/theme/lang-switcher.js`
- `docs/src/theme/lang-switcher.js`
- `docs/ja/src/theme/lang-switcher.js`

## Test plan

- [ ] Open the GitHub Pages site (or `mdbook serve`), navigate to any page, verify the translation bar link is visible and clickable at the left side
- [ ] Confirm the next-page `>` button still works on the right side without overlap

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)