### PR TITLE
feat(ci): use GitHub App for release automation

### DIFF
--- a/.github/workflows/auto-version-tag.yml
+++ b/.github/workflows/auto-version-tag.yml
@@ -27,9 +27,17 @@ jobs:
       tag_name: ${{ steps.set_tag.outputs.tag_name }}
 
     steps:
+      - name: Generate Token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout target SHA
         uses: actions/checkout@v4
         with:
+          token: ${{ steps.generate_token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Rust


### PR DESCRIPTION
This PR updates the 'Auto Version Tag' workflow to use a GitHub App for authentication. This allows the workflow to bypass branch protection rules on 'main' when pushing version-bump commits and tags.