### PR TITLE
fix(ci): pass secrets to auto-version-tag reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
   create_tag:
     name: Bump version and create tag
     uses: ./.github/workflows/auto-version-tag.yml
+    secrets: inherit
     permissions:
       contents: write
 


### PR DESCRIPTION
## Problem

Release workflow fails immediately with:

```
Error: Input required and not supplied: app-id
```

`release.yml` calls `auto-version-tag.yml` via `workflow_call` but does not pass `secrets: inherit`. Reusable workflows do not inherit secrets from the caller by default — `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` are both empty strings inside the called workflow, causing `actions/create-github-app-token` to reject them.

## Fix

Add `secrets: inherit` to the `create_tag` job in `release.yml`.

## Test plan

- [ ] Re-run Release workflow after this merges — `generate_token` step should succeed and proceed to version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)