### PR TITLE
fix(ci): update integration_test.sh package name after workspace migration

### DIFF
--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -49,7 +49,7 @@ echo "MinIO: ready"
 # ── 4. Build CLI ─────────────────────────────────────────────────────────────
 echo "[4/8] Building CLI (s3,postgres features)..."
 cd "$ROOT_DIR"
-cargo build -p edgesentry-rs --features s3,postgres --release >/dev/null
+cargo build -p edgesentry-audit --features s3,postgres --release >/dev/null
 
 EDS="$ROOT_DIR/target/release/eds"
 
@@ -117,7 +117,7 @@ echo "[8/8] Running Rust S3 integration tests..."
   TEST_S3_ACCESS_KEY="$MINIO_ACCESS_KEY" \
   TEST_S3_SECRET_KEY="$MINIO_SECRET_KEY" \
   TEST_S3_BUCKET="$MINIO_BUCKET" \
-  cargo test -p edgesentry-rs --features s3 --test integration -- --nocapture
+  cargo test -p edgesentry-audit --features s3 --test integration -- --nocapture
 )
 
 echo ""


### PR DESCRIPTION
Fixes Integration #82.

## Root cause

`scripts/integration_test.sh` referenced `-p edgesentry-rs` which is no longer a workspace member after the edgesentry-inspect migration PR. The CLI binary and `s3`/`postgres` features live in `edgesentry-audit`.

## Changes

- `cargo build -p edgesentry-rs` → `cargo build -p edgesentry-audit` (step 4/8)
- `cargo test -p edgesentry-rs` → `cargo test -p edgesentry-audit` (step 8/8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)