### PR TITLE
docs(inspect): add trilink-core API stabilisation items to Foundation table

### DIFF
--- a/docs/inspect/en/src/roadmap.md
+++ b/docs/inspect/en/src/roadmap.md
@@ -25,9 +25,9 @@ They are tracked and implemented in the [`trilink-core`](https://github.com/edge
 | [#34](https://github.com/edgesentry/trilink-core/issues/34) | Project → unproject round-trip tests | Done |
 | [#39](https://github.com/edgesentry/trilink-core/issues/39) | `HeightMap` dimension naming (`cols/rows` → `width/height`) | Done |
 | [#40](https://github.com/edgesentry/trilink-core/issues/40) | Coordinate precision decision (`Point3D` stays `f32`) | Done |
-| [#38](https://github.com/edgesentry/trilink-core/issues/38) | Adopt glam for `Transform4x4` / `Point3D` (SIMD, inversion) | In Review |
+| [#38](https://github.com/edgesentry/trilink-core/issues/38) | Adopt glam for `Transform4x4` / `Point3D` (SIMD, inversion) | Done |
 
-Do not start M2 until #38 merges.
+All foundation items are merged. M2 is unblocked.
 
 ---
 

--- a/docs/inspect/ja/src/roadmap.md
+++ b/docs/inspect/ja/src/roadmap.md
@@ -25,9 +25,9 @@
 | [#34](https://github.com/edgesentry/trilink-core/issues/34) | 投影 → 逆投影ラウンドトリップテスト | 完了 |
 | [#39](https://github.com/edgesentry/trilink-core/issues/39) | `HeightMap` の次元命名統一（`cols/rows` → `width/height`） | 完了 |
 | [#40](https://github.com/edgesentry/trilink-core/issues/40) | 座標精度の設計決定（`Point3D` は `f32` を維持） | 完了 |
-| [#38](https://github.com/edgesentry/trilink-core/issues/38) | `Transform4x4` / `Point3D` への glam 採用（SIMD・行列逆変換） | レビュー中 |
+| [#38](https://github.com/edgesentry/trilink-core/issues/38) | `Transform4x4` / `Point3D` への glam 採用（SIMD・行列逆変換） | 完了 |
 
-#38 がマージされるまで M2 を開始しないこと。
+基盤の全イシューがマージ済みです。M2 の実装を開始できます。
 
 ---
 


### PR DESCRIPTION
## Summary

Adds #38, #39, #40 to the Foundation prerequisite table and marks all items complete now that trilink-core#54 has landed.

| Issue | Deliverable | Status |
|---|---|---|
| #39 | `HeightMap` dimension naming (`cols/rows` → `width/height`) | Done |
| #40 | Coordinate precision decision (`Point3D` stays `f32`) | Done |
| #38 | Adopt glam for `Transform4x4` / `Point3D` | Done (trilink-core#54) |

All foundation prerequisites are complete. M2 is unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)