### PR TITLE
feat(inspect): M4 — field PC pipeline CLI [OSS]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +102,16 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "async-trait"
@@ -816,6 +835,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,14 +1112,18 @@ dependencies = [
 name = "edgesentry-inspect"
 version = "0.1.3"
 dependencies = [
+ "clap",
  "glam",
  "image",
+ "mockito",
  "rstar",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
+ "toml",
  "trilink-core",
+ "ureq",
 ]
 
 [[package]]
@@ -1648,7 +1680,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1981,6 +2013,31 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.2",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -2442,10 +2499,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-lite"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -2484,7 +2570,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2897,6 +2983,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,6 +3218,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",
@@ -3336,7 +3429,7 @@ dependencies = [
 [[package]]
 name = "trilink-core"
 version = "0.1.0"
-source = "git+https://github.com/edgesentry/trilink-core?branch=main#61fab73a748bd2dd5cfb2fc81884d0b7cf3b9d32"
+source = "git+https://github.com/edgesentry/trilink-core?branch=main#889bdc21a600003cf9efd4b0edb519f4f31c34c2"
 dependencies = [
  "glam",
  "serde",
@@ -3393,6 +3486,22 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -3614,6 +3723,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/crates/edgesentry-inspect/Cargo.toml
+++ b/crates/edgesentry-inspect/Cargo.toml
@@ -13,14 +13,22 @@ documentation = "https://edgesentry.github.io/edgesentry-rs/inspect/en/"
 name = "edgesentry_inspect"
 path = "src/lib.rs"
 
+[[bin]]
+name = "edgesentry-inspect"
+path = "src/main.rs"
+
 [dependencies]
 trilink-core = { git = "https://github.com/edgesentry/trilink-core", branch = "main" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+clap = { workspace = true }
 rstar = "0.12"
 glam = "0.32.1"
 image = { version = "0.25", default-features = false, features = ["png"] }
+toml = "0.8"
+ureq = "2"
 
 [dev-dependencies]
 tempfile = "3"
+mockito = "1"

--- a/crates/edgesentry-inspect/config.example.toml
+++ b/crates/edgesentry-inspect/config.example.toml
@@ -1,0 +1,33 @@
+# edgesentry-inspect — example configuration
+#
+# Copy to config.toml and adjust paths before running:
+#   edgesentry-inspect scan --config config.toml
+
+# Path to the IFC design file (reference model).
+ifc_path = "design.ifc"
+
+# Path to the as-built scan in ASCII PLY format.
+scan_path = "scan.ply"
+
+# Pinhole camera calibration.
+# Use CameraIntrinsics::from_fov to derive fx/fy/cx/cy from field-of-view if needed.
+[camera]
+fx     = 800.0   # horizontal focal length (pixels)
+fy     = 800.0   # vertical focal length (pixels)
+cx     = 960.0   # principal point X (pixels) — typically width / 2
+cy     = 540.0   # principal point Y (pixels) — typically height / 2
+width  = 1920    # image width (pixels)
+height = 1080    # image height (pixels)
+
+# AI inference settings.
+# mode = "off"  — skip AI detection; deviation report and heatmap still produced.
+# mode = "http" — POST depth-map PNG to `endpoint` and back-project detections.
+[inference]
+mode             = "off"
+# endpoint       = "http://localhost:8000/detect"   # required when mode = "http"
+fallback_depth_m = 2.0   # depth used when ToF reading is unavailable (metres)
+
+# Output settings.
+[output]
+dir          = "./output"   # directory for report.json and heatmap.png
+threshold_mm = 10.0         # scan points within this distance are considered compliant

--- a/crates/edgesentry-inspect/src/config.rs
+++ b/crates/edgesentry-inspect/src/config.rs
@@ -1,0 +1,90 @@
+//! Configuration for `edgesentry-inspect scan`.
+//!
+//! Loaded from a TOML file passed via `--config`.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level scan configuration.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ScanConfig {
+    /// Path to the IFC design file (reference model).
+    pub ifc_path: PathBuf,
+    /// Path to the scan point cloud (PLY, ASCII format).
+    pub scan_path: PathBuf,
+    /// Pinhole camera calibration used for depth-map projection and heatmap rendering.
+    pub camera: CameraConfig,
+    /// AI inference settings.
+    pub inference: InferenceConfig,
+    /// Output directory and deviation threshold.
+    pub output: OutputConfig,
+}
+
+/// Pinhole camera calibration parameters.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CameraConfig {
+    pub fx: f64,
+    pub fy: f64,
+    pub cx: f64,
+    pub cy: f64,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// Inference mode and endpoint configuration.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct InferenceConfig {
+    /// `"off"` — skip AI inference; `"http"` — POST depth-map PNG to `endpoint`.
+    pub mode: InferenceMode,
+    /// Required when `mode = "http"`. URL of the inference service.
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    /// Fallback depth (metres) used when a detection pixel has no ToF reading.
+    #[serde(default = "default_fallback_depth")]
+    pub fallback_depth_m: f32,
+}
+
+fn default_fallback_depth() -> f32 {
+    2.0
+}
+
+/// Whether to run AI defect detection.
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum InferenceMode {
+    /// Skip AI inference — deviation report and heatmap are still produced.
+    Off,
+    /// POST the depth-map PNG to an HTTP inference server (e.g. YOLOv8).
+    Http,
+}
+
+/// Output paths and quality threshold.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct OutputConfig {
+    /// Directory where `report.json` and `heatmap.png` are written.
+    pub dir: PathBuf,
+    /// Scan points within this distance of the reference model are considered compliant.
+    #[serde(default = "default_threshold")]
+    pub threshold_mm: f64,
+}
+
+fn default_threshold() -> f64 {
+    10.0
+}
+
+/// Parse a [`ScanConfig`] from a TOML file.
+pub fn load_config(path: &std::path::Path) -> Result<ScanConfig, ConfigError> {
+    let text = std::fs::read_to_string(path)?;
+    let cfg = toml::from_str(&text)?;
+    Ok(cfg)
+}
+
+/// Errors produced while loading the config.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("TOML parse error: {0}")]
+    Toml(#[from] toml::de::Error),
+}

--- a/crates/edgesentry-inspect/src/deviation.rs
+++ b/crates/edgesentry-inspect/src/deviation.rs
@@ -22,6 +22,33 @@ pub struct DeviationReport {
     pub point_count: usize,
 }
 
+/// Compute per-point nearest-neighbour distances (in mm) between `scan` and `reference`.
+///
+/// Returns a `Vec` parallel to `scan`; each entry is the distance in millimetres
+/// to the closest point in `reference`.
+///
+/// # Panics
+///
+/// Panics if `reference` is empty.
+pub fn per_point_deviations_mm(scan: &[Point3D], reference: &[Point3D]) -> Vec<f64> {
+    assert!(!reference.is_empty(), "reference cloud must not be empty");
+
+    let ref_pts: Vec<[f32; 3]> = reference.iter().map(|p| [p.x, p.y, p.z]).collect();
+    let tree = RTree::bulk_load(ref_pts);
+
+    scan.iter()
+        .map(|pt| {
+            let nearest = tree.nearest_neighbor(&[pt.x, pt.y, pt.z]).unwrap();
+            let dist_sq: f32 = nearest
+                .iter()
+                .zip([pt.x, pt.y, pt.z])
+                .map(|(&a, b)| (a - b).powi(2))
+                .sum();
+            (dist_sq as f64).sqrt() * 1000.0
+        })
+        .collect()
+}
+
 /// Compute nearest-neighbour deviation between `scan` and `reference` clouds.
 ///
 /// For each point in `scan` the closest point in `reference` is found via a
@@ -47,33 +74,26 @@ pub fn compute_deviation(
         };
     }
 
-    // Build R*-tree from reference cloud.
-    let ref_pts: Vec<[f32; 3]> = reference.iter().map(|p| [p.x, p.y, p.z]).collect();
-    let tree = RTree::bulk_load(ref_pts);
-
-    let mut max_dist_sq: f64 = 0.0;
-    let mut sum_dist_mm: f64 = 0.0;
+    let deviations = per_point_deviations_mm(scan, reference);
+    let n = deviations.len();
+    let mut max_mm: f64 = 0.0;
+    let mut sum_mm: f64 = 0.0;
     let mut compliant_count: usize = 0;
 
-    for pt in scan {
-        let nearest = tree.nearest_neighbor(&[pt.x, pt.y, pt.z]).unwrap();
-        let dist_sq = nearest.iter().zip([pt.x, pt.y, pt.z]).map(|(&a, b)| (a - b).powi(2)).sum::<f32>() as f64;
-        let dist_mm = dist_sq.sqrt() * 1000.0;
-
-        if dist_sq > max_dist_sq {
-            max_dist_sq = dist_sq;
+    for &d in &deviations {
+        if d > max_mm {
+            max_mm = d;
         }
-        sum_dist_mm += dist_mm;
-        if dist_mm <= threshold_mm {
+        sum_mm += d;
+        if d <= threshold_mm {
             compliant_count += 1;
         }
     }
 
-    let n = scan.len();
     DeviationReport {
         compliant_pct: compliant_count as f64 / n as f64 * 100.0,
-        max_deviation_mm: max_dist_sq.sqrt() * 1000.0,
-        mean_deviation_mm: sum_dist_mm / n as f64,
+        max_deviation_mm: max_mm,
+        mean_deviation_mm: sum_mm / n as f64,
         point_count: n,
     }
 }

--- a/crates/edgesentry-inspect/src/inference.rs
+++ b/crates/edgesentry-inspect/src/inference.rs
@@ -1,0 +1,127 @@
+//! AI inference client for defect detection.
+//!
+//! Encodes a [`trilink_core::DepthMap`] as a grayscale PNG and POSTs it to an
+//! HTTP inference server (e.g. YOLOv8). The server responds with a JSON array
+//! of bounding boxes.
+
+use image::codecs::png::PngEncoder;
+use image::ImageEncoder;
+use serde::Deserialize;
+use trilink_core::{BBox2D, DepthMap};
+
+/// Errors produced during inference.
+#[derive(Debug, thiserror::Error)]
+pub enum InferenceError {
+    #[error("failed to encode depth map as PNG: {0}")]
+    Encode(String),
+    #[error("HTTP request failed: {0}")]
+    Http(String),
+    #[error("failed to parse inference response: {0}")]
+    Parse(#[from] serde_json::Error),
+}
+
+/// JSON shape returned by the inference server.
+#[derive(Debug, Deserialize)]
+struct DetectionJson {
+    u0: f32,
+    v0: f32,
+    u1: f32,
+    v1: f32,
+}
+
+/// Encode a [`DepthMap`] as an 8-bit grayscale PNG.
+///
+/// Finite depth values are normalised to `[0, 255]`. Pixels with no depth
+/// (`f32::INFINITY`) map to black (0).
+pub fn depth_map_to_png(dm: &DepthMap) -> Result<Vec<u8>, InferenceError> {
+    let finite: Vec<f32> = dm.data.iter().copied().filter(|v| v.is_finite()).collect();
+
+    let (d_min, d_range) = if finite.is_empty() {
+        (0.0f32, 1.0f32)
+    } else {
+        let mn = finite.iter().copied().fold(f32::INFINITY, f32::min);
+        let mx = finite.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let range = if (mx - mn).abs() < 1e-6 { 1.0 } else { mx - mn };
+        (mn, range)
+    };
+
+    let pixels: Vec<u8> = dm
+        .data
+        .iter()
+        .map(|&v| {
+            if v.is_infinite() {
+                0u8
+            } else {
+                ((v - d_min) / d_range * 255.0).clamp(0.0, 255.0) as u8
+            }
+        })
+        .collect();
+
+    let mut buf = Vec::new();
+    PngEncoder::new(&mut buf)
+        .write_image(
+            &pixels,
+            dm.width,
+            dm.height,
+            image::ExtendedColorType::L8,
+        )
+        .map_err(|e| InferenceError::Encode(e.to_string()))?;
+
+    Ok(buf)
+}
+
+/// POST a depth-map PNG to an HTTP inference server and return bounding boxes.
+///
+/// The server must accept `Content-Type: image/png` and respond with a JSON
+/// array of objects with `u0`, `v0`, `u1`, `v1` fields (pixel coordinates).
+pub fn http_infer(endpoint: &str, png_bytes: &[u8]) -> Result<Vec<BBox2D>, InferenceError> {
+    let response = ureq::post(endpoint)
+        .set("Content-Type", "image/png")
+        .send_bytes(png_bytes)
+        .map_err(|e| InferenceError::Http(e.to_string()))?;
+
+    let body = response
+        .into_string()
+        .map_err(|e| InferenceError::Http(e.to_string()))?;
+
+    let detections: Vec<DetectionJson> = serde_json::from_str(&body)?;
+
+    Ok(detections
+        .into_iter()
+        .map(|d| BBox2D { u0: d.u0, v0: d.v0, u1: d.u1, v1: d.v1 })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn flat_depth_map(w: u32, h: u32, depth: f32) -> DepthMap {
+        DepthMap { width: w, height: h, data: vec![depth; (w * h) as usize] }
+    }
+
+    #[test]
+    fn depth_map_to_png_produces_valid_png() {
+        let dm = flat_depth_map(4, 4, 2.0);
+        let png = depth_map_to_png(&dm).unwrap();
+        // PNG magic bytes: 0x89 0x50 0x4E 0x47
+        assert_eq!(&png[..4], &[0x89, 0x50, 0x4e, 0x47]);
+    }
+
+    #[test]
+    fn depth_map_to_png_all_infinity_produces_black() {
+        let dm = DepthMap { width: 2, height: 2, data: vec![f32::INFINITY; 4] };
+        let png = depth_map_to_png(&dm).unwrap();
+        assert!(!png.is_empty(), "PNG should still be produced for all-infinity map");
+    }
+
+    #[test]
+    fn depth_map_to_png_size_matches() {
+        let dm = flat_depth_map(8, 6, 1.5);
+        let png = depth_map_to_png(&dm).unwrap();
+        // Decode and check dimensions
+        let img = image::load_from_memory(&png).unwrap();
+        assert_eq!(img.width(), 8);
+        assert_eq!(img.height(), 6);
+    }
+}

--- a/crates/edgesentry-inspect/src/lib.rs
+++ b/crates/edgesentry-inspect/src/lib.rs
@@ -1,8 +1,13 @@
 // edgesentry-inspect — edge-first deviation detection for construction and maritime inspection.
 // M2: IFC Loader and Deviation Engine.
 // M3: Heatmap Rendering.
+// M4: Field PC Pipeline CLI.
 
+pub mod config;
 pub mod deviation;
 pub mod heatmap;
 pub mod ifc;
+pub mod inference;
+pub mod pipeline;
+pub mod ply;
 pub mod report;

--- a/crates/edgesentry-inspect/src/main.rs
+++ b/crates/edgesentry-inspect/src/main.rs
@@ -1,0 +1,75 @@
+//! `edgesentry-inspect` — field PC CLI for IFC-based deviation detection.
+//!
+//! # Usage
+//!
+//! ```sh
+//! edgesentry-inspect scan --config config.toml
+//! ```
+
+use clap::{Parser, Subcommand};
+
+use edgesentry_inspect::{
+    config::load_config,
+    pipeline::run_scan,
+};
+
+#[derive(Parser)]
+#[command(
+    name = "edgesentry-inspect",
+    about = "Edge-first 3D scan vs. IFC deviation detection",
+    version
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run a full scan: load IFC + PLY, compute deviation, render heatmap.
+    Scan {
+        /// Path to the TOML configuration file.
+        #[arg(short, long, default_value = "config.toml")]
+        config: std::path::PathBuf,
+    },
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Scan { config } => {
+            let cfg = match load_config(&config) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("error: failed to load config '{}': {e}", config.display());
+                    std::process::exit(1);
+                }
+            };
+
+            println!("edgesentry-inspect scan");
+            println!("  IFC   : {}", cfg.ifc_path.display());
+            println!("  scan  : {}", cfg.scan_path.display());
+            println!("  output: {}", cfg.output.dir.display());
+
+            match run_scan(&cfg) {
+                Ok(out) => {
+                    println!("\n=== Deviation Report ===");
+                    println!("  point_count      : {}", out.report.point_count);
+                    println!("  compliant_pct    : {:.1}%", out.report.compliant_pct);
+                    println!("  max_deviation_mm : {:.3} mm", out.report.max_deviation_mm);
+                    println!("  mean_deviation_mm: {:.3} mm", out.report.mean_deviation_mm);
+                    if out.detection_count > 0 {
+                        println!("  ai_detections    : {}", out.detection_count);
+                    }
+                    println!("\n  report  → {}", out.report_path.display());
+                    println!("  heatmap → {}", out.heatmap_path.display());
+                }
+                Err(e) => {
+                    eprintln!("error: scan failed: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+}

--- a/crates/edgesentry-inspect/src/pipeline.rs
+++ b/crates/edgesentry-inspect/src/pipeline.rs
@@ -1,0 +1,143 @@
+//! End-to-end scan pipeline.
+//!
+//! [`run_scan`] wires together all M2–M4 components:
+//! IFC loader → deviation engine → depth-map projection → AI inference →
+//! unproject detections → heatmap → JSON report.
+
+use std::path::PathBuf;
+
+use trilink_core::{
+    BBox2D, CameraIntrinsics, Point3D, PointCloud, Transform4x4,
+    bridge::{project_to_depth_map, unproject},
+};
+
+use crate::{
+    config::{InferenceMode, ScanConfig},
+    deviation::{compute_deviation, per_point_deviations_mm, DeviationReport},
+    heatmap::{render_heatmap, write_heatmap_png},
+    ifc::load_ifc_points,
+    inference::{depth_map_to_png, http_infer, InferenceError},
+    ply::{load_ply_points, PlyError},
+    report::{write_report, ReportError},
+};
+
+/// Outputs produced by a successful scan run.
+#[derive(Debug)]
+pub struct ScanOutput {
+    /// Deviation summary statistics.
+    pub report: DeviationReport,
+    /// Absolute path to the written `report.json`.
+    pub report_path: PathBuf,
+    /// Absolute path to the written `heatmap.png`.
+    pub heatmap_path: PathBuf,
+    /// Number of AI detections back-projected to 3D (0 when `mode = "off"`).
+    pub detection_count: usize,
+    /// 3D world positions for each detection (parallel to `detection_count`).
+    pub world_detections: Vec<Point3D>,
+}
+
+/// Errors that can occur during a scan run.
+#[derive(Debug, thiserror::Error)]
+pub enum ScanError {
+    #[error("IFC load failed: {0}")]
+    Ifc(String),
+    #[error("PLY load failed: {0}")]
+    Ply(#[from] PlyError),
+    #[error("inference error: {0}")]
+    Inference(#[from] InferenceError),
+    #[error("config error: {0}")]
+    Config(String),
+    #[error("report write failed: {0}")]
+    Report(#[from] ReportError),
+    #[error("heatmap write failed: {0}")]
+    Heatmap(String),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Run the full M4 scan pipeline from a [`ScanConfig`].
+///
+/// # Pipeline steps
+///
+/// 1. Load IFC design file → reference point cloud
+/// 2. Load PLY scan file → as-built point cloud
+/// 3. Build camera model from config
+/// 4. Project scan to depth map (pinhole)
+/// 5. Optionally POST depth map to HTTP inference server → bounding boxes
+/// 6. Unproject each detection bbox to 3D world coordinates
+/// 7. Compute per-point deviation (scan vs. IFC reference)
+/// 8. Render deviation heatmap PNG
+/// 9. Write `report.json` and `heatmap.png` to the output directory
+pub fn run_scan(config: &ScanConfig) -> Result<ScanOutput, ScanError> {
+    // Step 1 — IFC reference cloud
+    let reference =
+        load_ifc_points(&config.ifc_path).map_err(|e| ScanError::Ifc(e.to_string()))?;
+
+    // Step 2 — Scan point cloud
+    let scan = load_ply_points(&config.scan_path)?;
+
+    // Step 3 — Camera model (identity pose: sensor frame == world frame for this run)
+    let k = CameraIntrinsics {
+        fx: config.camera.fx,
+        fy: config.camera.fy,
+        cx: config.camera.cx,
+        cy: config.camera.cy,
+    };
+    let pose = Transform4x4::identity();
+
+    // Step 4 — Depth map
+    let cloud = PointCloud { capture_ts_us: 0, points: scan.clone(), intensities: None };
+    let depth_map = project_to_depth_map(&cloud, &pose, &k, config.camera.width, config.camera.height);
+
+    // Step 5 — AI inference (optional)
+    let detections: Vec<BBox2D> = match &config.inference.mode {
+        InferenceMode::Off => vec![],
+        InferenceMode::Http => {
+            let endpoint = config.inference.endpoint.as_deref().ok_or_else(|| {
+                ScanError::Config(
+                    "inference.endpoint is required when inference.mode = \"http\"".into(),
+                )
+            })?;
+            let png = depth_map_to_png(&depth_map)?;
+            http_infer(endpoint, &png)?
+        }
+    };
+
+    // Step 6 — Unproject detections to 3D world positions
+    let world_detections: Vec<Point3D> = detections
+        .iter()
+        .map(|bbox| unproject(bbox, None, config.inference.fallback_depth_m, &k, &pose))
+        .collect();
+
+    // Step 7 — Deviation (per-point + summary)
+    let deviations_mm = per_point_deviations_mm(&scan, &reference);
+    let report = compute_deviation(&scan, &reference, config.output.threshold_mm);
+
+    // Step 8 — Heatmap
+    let img = render_heatmap(
+        &scan,
+        &deviations_mm,
+        &pose,
+        &k,
+        config.camera.width,
+        config.camera.height,
+        config.output.threshold_mm,
+    );
+
+    // Step 9 — Write outputs
+    std::fs::create_dir_all(&config.output.dir)?;
+    let report_path = config.output.dir.join("report.json");
+    let heatmap_path = config.output.dir.join("heatmap.png");
+
+    write_report(&report, &report_path)?;
+    write_heatmap_png(&img, &heatmap_path)
+        .map_err(|e| ScanError::Heatmap(e.to_string()))?;
+
+    Ok(ScanOutput {
+        report,
+        report_path,
+        heatmap_path,
+        detection_count: detections.len(),
+        world_detections,
+    })
+}

--- a/crates/edgesentry-inspect/src/ply.rs
+++ b/crates/edgesentry-inspect/src/ply.rs
@@ -1,0 +1,161 @@
+//! Minimal ASCII PLY reader.
+//!
+//! Reads `x`, `y`, `z` float properties from the `vertex` element of an ASCII
+//! PLY file. Binary PLY and additional properties are ignored.
+
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+use trilink_core::Point3D;
+
+/// Errors produced while loading a PLY file.
+#[derive(Debug, thiserror::Error)]
+pub enum PlyError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid PLY header: {0}")]
+    Header(String),
+    #[error("PLY parse error at vertex {index}: {msg}")]
+    Parse { index: usize, msg: String },
+}
+
+/// Load `x y z` vertices from an ASCII PLY file.
+///
+/// Only the `vertex` element is read; additional elements (faces, edges, …)
+/// are ignored. Properties other than `x`, `y`, `z` are silently skipped.
+pub fn load_ply_points(path: &Path) -> Result<Vec<Point3D>, PlyError> {
+    let file = std::fs::File::open(path)?;
+    let reader = BufReader::new(file);
+    let mut lines = reader.lines();
+
+    // --- Parse header ---
+    let first = lines
+        .next()
+        .ok_or_else(|| PlyError::Header("empty file".into()))??;
+    if first.trim() != "ply" {
+        return Err(PlyError::Header("missing 'ply' magic".into()));
+    }
+
+    let mut vertex_count: usize = 0;
+    let mut x_idx: Option<usize> = None;
+    let mut y_idx: Option<usize> = None;
+    let mut z_idx: Option<usize> = None;
+    let mut prop_idx: usize = 0;
+    let mut in_vertex = false;
+
+    loop {
+        let line = lines
+            .next()
+            .ok_or_else(|| PlyError::Header("unexpected end of header".into()))??;
+        let line = line.trim();
+
+        if line == "end_header" {
+            break;
+        }
+
+        if line.starts_with("element vertex") {
+            in_vertex = true;
+            vertex_count = line
+                .split_whitespace()
+                .nth(2)
+                .ok_or_else(|| PlyError::Header("missing vertex count".into()))?
+                .parse::<usize>()
+                .map_err(|e| PlyError::Header(e.to_string()))?;
+            prop_idx = 0;
+        } else if line.starts_with("element ") {
+            in_vertex = false;
+        } else if line.starts_with("property ") && in_vertex {
+            let name = line.split_whitespace().nth(2).unwrap_or("");
+            match name {
+                "x" => x_idx = Some(prop_idx),
+                "y" => y_idx = Some(prop_idx),
+                "z" => z_idx = Some(prop_idx),
+                _ => {}
+            }
+            prop_idx += 1;
+        }
+    }
+
+    let x_col = x_idx.ok_or_else(|| PlyError::Header("no 'x' property in vertex element".into()))?;
+    let y_col = y_idx.ok_or_else(|| PlyError::Header("no 'y' property in vertex element".into()))?;
+    let z_col = z_idx.ok_or_else(|| PlyError::Header("no 'z' property in vertex element".into()))?;
+
+    // --- Parse vertex data ---
+    let mut points = Vec::with_capacity(vertex_count);
+
+    for (i, line_result) in lines.take(vertex_count).enumerate() {
+        let line = line_result?;
+        let parts: Vec<&str> = line.trim().split_whitespace().collect();
+
+        let parse = |col: usize| -> Result<f32, PlyError> {
+            parts
+                .get(col)
+                .ok_or_else(|| PlyError::Parse {
+                    index: i,
+                    msg: format!("missing column {col}"),
+                })?
+                .parse::<f32>()
+                .map_err(|e| PlyError::Parse { index: i, msg: e.to_string() })
+        };
+
+        points.push(Point3D { x: parse(x_col)?, y: parse(y_col)?, z: parse(z_col)? });
+    }
+
+    Ok(points)
+}
+
+/// Write `x y z` vertices to an ASCII PLY file.
+///
+/// Used in tests to generate fixture scan files.
+pub fn write_ply_points(path: &Path, points: &[Point3D]) -> Result<(), PlyError> {
+    use std::io::Write;
+    let mut f = std::fs::File::create(path)?;
+    writeln!(f, "ply")?;
+    writeln!(f, "format ascii 1.0")?;
+    writeln!(f, "element vertex {}", points.len())?;
+    writeln!(f, "property float x")?;
+    writeln!(f, "property float y")?;
+    writeln!(f, "property float z")?;
+    writeln!(f, "end_header")?;
+    for p in points {
+        writeln!(f, "{} {} {}", p.x, p.y, p.z)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn roundtrip_ascii_ply() {
+        let pts = vec![
+            Point3D { x: 1.0, y: 2.0, z: 3.0 },
+            Point3D { x: 4.5, y: -1.0, z: 0.0 },
+        ];
+        let f = NamedTempFile::new().unwrap();
+        write_ply_points(f.path(), &pts).unwrap();
+        let loaded = load_ply_points(f.path()).unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert!((loaded[0].x - 1.0).abs() < 1e-5);
+        assert!((loaded[1].z - 0.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn missing_magic_returns_error() {
+        let f = NamedTempFile::new().unwrap();
+        std::fs::write(f.path(), "not-a-ply-file\n").unwrap();
+        assert!(load_ply_points(f.path()).is_err());
+    }
+
+    #[test]
+    fn extra_properties_are_skipped() {
+        let content = "ply\nformat ascii 1.0\nelement vertex 1\nproperty float x\nproperty float y\nproperty float z\nproperty float intensity\nend_header\n1.0 2.0 3.0 0.5\n";
+        let f = NamedTempFile::new().unwrap();
+        std::fs::write(f.path(), content).unwrap();
+        let pts = load_ply_points(f.path()).unwrap();
+        assert_eq!(pts.len(), 1);
+        assert!((pts[0].x - 1.0).abs() < 1e-5);
+    }
+}

--- a/crates/edgesentry-inspect/tests/scan_pipeline_integration.rs
+++ b/crates/edgesentry-inspect/tests/scan_pipeline_integration.rs
@@ -1,0 +1,162 @@
+//! End-to-end integration tests for the M4 scan pipeline.
+//!
+//! Tests run against the bundled `sample.ifc` fixture and a programmatically
+//! generated PLY scan, so no external data or network access is required.
+
+use std::path::Path;
+
+use edgesentry_inspect::{
+    config::{InferenceConfig, InferenceMode, OutputConfig, ScanConfig, CameraConfig},
+    pipeline::run_scan,
+    ply::write_ply_points,
+};
+use tempfile::TempDir;
+use trilink_core::Point3D;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn sample_ifc() -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/sample.ifc")
+}
+
+fn make_scan_with_defect() -> Vec<Point3D> {
+    // Clone the reference set (7 points identical to sample.ifc) then displace
+    // the last one by 15 mm along Z — the same simulation as the demo example.
+    let reference = edgesentry_inspect::ifc::load_ifc_points(&sample_ifc())
+        .expect("sample.ifc must be loadable");
+    let mut scan = reference;
+    if let Some(last) = scan.last_mut() {
+        last.z += 0.015;
+    }
+    scan
+}
+
+fn default_camera() -> CameraConfig {
+    // Small image: keeps test fast, still exercises the full projection path.
+    CameraConfig { fx: 100.0, fy: 100.0, cx: 100.0, cy: 100.0, width: 200, height: 200 }
+}
+
+// ---------------------------------------------------------------------------
+// Deviation-only pipeline (mode = "off")
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scan_off_mode_produces_report_and_heatmap() {
+    let tmp = TempDir::new().unwrap();
+
+    // Write a PLY scan
+    let scan_pts = make_scan_with_defect();
+    let ply_path = tmp.path().join("scan.ply");
+    write_ply_points(&ply_path, &scan_pts).unwrap();
+
+    let cfg = ScanConfig {
+        ifc_path: sample_ifc(),
+        scan_path: ply_path,
+        camera: default_camera(),
+        inference: InferenceConfig {
+            mode: InferenceMode::Off,
+            endpoint: None,
+            fallback_depth_m: 2.0,
+        },
+        output: OutputConfig { dir: tmp.path().join("out"), threshold_mm: 10.0 },
+    };
+
+    let out = run_scan(&cfg).expect("pipeline must succeed");
+
+    // Report fields
+    assert_eq!(out.report.point_count, 7);
+    assert!(out.report.max_deviation_mm > 14.0, "displaced point should exceed 14 mm");
+    assert!(out.report.compliant_pct < 100.0, "at least one non-compliant point");
+    assert!(out.report.compliant_pct > 0.0, "at least some compliant points");
+    assert_eq!(out.detection_count, 0, "no AI detections in off mode");
+
+    // Output files exist
+    assert!(out.report_path.exists(), "report.json must be written");
+    assert!(out.heatmap_path.exists(), "heatmap.png must be written");
+
+    // report.json is valid JSON with expected fields
+    let json = std::fs::read_to_string(&out.report_path).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(v["point_count"].as_u64().unwrap() == 7);
+
+    // heatmap.png is a valid PNG (correct magic bytes)
+    let png = std::fs::read(&out.heatmap_path).unwrap();
+    assert_eq!(&png[..4], &[0x89, 0x50, 0x4e, 0x47], "heatmap must be a valid PNG");
+}
+
+#[test]
+fn scan_zero_deviation_fully_compliant() {
+    let tmp = TempDir::new().unwrap();
+
+    // Scan identical to reference → all points compliant
+    let reference = edgesentry_inspect::ifc::load_ifc_points(&sample_ifc()).unwrap();
+    let ply_path = tmp.path().join("scan.ply");
+    write_ply_points(&ply_path, &reference).unwrap();
+
+    let cfg = ScanConfig {
+        ifc_path: sample_ifc(),
+        scan_path: ply_path,
+        camera: default_camera(),
+        inference: InferenceConfig {
+            mode: InferenceMode::Off,
+            endpoint: None,
+            fallback_depth_m: 2.0,
+        },
+        output: OutputConfig { dir: tmp.path().join("out"), threshold_mm: 10.0 },
+    };
+
+    let out = run_scan(&cfg).unwrap();
+    assert!((out.report.compliant_pct - 100.0).abs() < 1e-6);
+    assert!(out.report.max_deviation_mm < 1e-3);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP inference mode (mock server)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn scan_http_mode_returns_detections() {
+    let tmp = TempDir::new().unwrap();
+    let scan_pts = make_scan_with_defect();
+    let ply_path = tmp.path().join("scan.ply");
+    write_ply_points(&ply_path, &scan_pts).unwrap();
+
+    // Mock inference server: always returns one bounding box
+    let mut server = mockito::Server::new();
+    let _mock = server
+        .mock("POST", "/detect")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"[{"u0":50.0,"v0":50.0,"u1":80.0,"v1":80.0}]"#)
+        .create();
+
+    let endpoint = format!("{}/detect", server.url());
+
+    let cfg = ScanConfig {
+        ifc_path: sample_ifc(),
+        scan_path: ply_path,
+        camera: default_camera(),
+        inference: InferenceConfig {
+            mode: InferenceMode::Http,
+            endpoint: Some(endpoint),
+            fallback_depth_m: 2.0,
+        },
+        output: OutputConfig { dir: tmp.path().join("out"), threshold_mm: 10.0 },
+    };
+
+    let out = run_scan(&cfg).unwrap();
+
+    assert_eq!(out.detection_count, 1, "mock server returns one detection");
+    assert_eq!(out.world_detections.len(), 1);
+    // The detection must have a finite world position
+    let wp = &out.world_detections[0];
+    assert!(wp.x.is_finite() && wp.y.is_finite() && wp.z.is_finite());
+
+    // Deviation report is still produced
+    assert_eq!(out.report.point_count, 7);
+    assert!(out.report_path.exists());
+    assert!(out.heatmap_path.exists());
+}


### PR DESCRIPTION
Closes #206

## Summary

- Adds `edgesentry-inspect scan --config config.toml` binary — wires M2 + M3 into a runnable CLI
- `src/config.rs` — TOML config: `ifc_path`, `scan_path`, `[camera]`, `[inference]` (`off`/`http`), `[output]`
- `src/ply.rs` — minimal ASCII PLY reader (reads x/y/z, skips extra properties) + writer used in tests
- `src/inference.rs` — `depth_map_to_png` (normalised grayscale PNG) + `http_infer` (POST PNG → `Vec<BBox2D>`)
- `src/pipeline.rs` — `run_scan()`: IFC → PLY → `project_to_depth_map` → optional HTTP inference → `unproject` → deviation → heatmap → `report.json` + `heatmap.png`
- `config.example.toml` — annotated example config
- `deviation.rs` refactored to expose `per_point_deviations_mm()` (no behaviour change)

## Test plan

- [x] `scan_off_mode_produces_report_and_heatmap` — displaced point detected, report.json + heatmap.png written
- [x] `scan_zero_deviation_fully_compliant` — identical scan/reference → 100% compliant
- [x] `scan_http_mode_returns_detections` — mockito mock server returns 1 bbox → 1 world detection back-projected
- [x] PLY unit tests: roundtrip, missing magic, extra properties skipped
- [x] PNG encoding tests: valid magic, correct dimensions, all-infinity map handled
- [x] All 31 tests pass

## Note on trilink-core dependency

`run_scan` calls `trilink_core::bridge::{project_to_depth_map, unproject}` via the `main` branch. The `project_point` function added in PR trilink-core#58 is not yet needed here (used for tracking/overlay — post-M4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)