### PR TITLE
feat(release): add Homebrew tap automation and set version to v0.1.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,3 +276,79 @@ jobs:
             --title "${TAG_NAME}" \
             --generate-notes \
             dist/**/*.tar.gz dist/**/*.zip dist/sbom/*.cdx.json
+
+  update_homebrew_tap:
+    name: Update Homebrew tap formula
+    runs-on: ubuntu-latest
+    needs: [create_tag, publish_github_release]
+    permissions:
+      contents: read
+
+    steps:
+      - name: Generate GitHub App token (scoped to homebrew-tap)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          repositories: homebrew-tap
+
+      - name: Compute checksums and update Formula/eds.rb
+        env:
+          TAG_NAME: ${{ needs.create_tag.outputs.tag_name }}
+        run: |
+          BASE_URL="https://github.com/edgesentry/edgesentry-rs/releases/download/${TAG_NAME}"
+          MACOS_ASSET="eds-${TAG_NAME}-aarch64-apple-darwin.tar.gz"
+          LINUX_ASSET="eds-${TAG_NAME}-x86_64-unknown-linux-gnu.tar.gz"
+
+          curl -fsSL -o "${MACOS_ASSET}" "${BASE_URL}/${MACOS_ASSET}"
+          curl -fsSL -o "${LINUX_ASSET}" "${BASE_URL}/${LINUX_ASSET}"
+
+          SHA256_MACOS=$(sha256sum "${MACOS_ASSET}" | awk '{print $1}')
+          SHA256_LINUX=$(sha256sum "${LINUX_ASSET}" | awk '{print $1}')
+
+          cat > eds.rb <<FORMULA
+          class Eds < Formula
+            desc "EdgeSentry unified CLI for tamper-evident audit and IFC scan inspection"
+            homepage "https://github.com/edgesentry/edgesentry-rs"
+            version "${TAG_NAME#v}"
+            license any_of: ["MIT", "Apache-2.0"]
+
+            on_macos do
+              on_arm do
+                url "${BASE_URL}/${MACOS_ASSET}"
+                sha256 "${SHA256_MACOS}"
+              end
+            end
+
+            on_linux do
+              on_intel do
+                url "${BASE_URL}/${LINUX_ASSET}"
+                sha256 "${SHA256_LINUX}"
+              end
+            end
+
+            def install
+              bin.install "eds"
+            end
+
+            test do
+              assert_match version.to_s, shell_output("#{bin}/eds --version")
+            end
+          end
+          FORMULA
+
+      - name: Push formula to homebrew-tap
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG_NAME: ${{ needs.create_tag.outputs.tag_name }}
+        run: |
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/edgesentry/homebrew-tap.git" tap
+          mkdir -p tap/Formula
+          cp eds.rb tap/Formula/eds.rb
+          cd tap
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add Formula/eds.rb
+          git commit -m "eds ${TAG_NAME}"
+          git push

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "edgesentry-audit"
-version = "0.3.0"
+version = "0.1.3"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "edgesentry-bridge"
-version = "0.3.0"
+version = "0.1.3"
 dependencies = [
  "cbindgen",
  "ed25519-dalek",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "edgesentry-inspect"
-version = "0.3.0"
+version = "0.1.3"
 dependencies = [
  "glam",
  "image",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "eds"
-version = "0.3.0"
+version = "0.1.3"
 dependencies = [
  "clap",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT OR Apache-2.0"
-version = "0.3.0"
+version = "0.1.3"
 repository = "https://github.com/edgesentry/edgesentry-rs"
 
 [workspace.dependencies]

--- a/docs/audit/en/src/cli.md
+++ b/docs/audit/en/src/cli.md
@@ -11,6 +11,12 @@ eds inspect <command>  — 3D scan vs. IFC deviation and AI detection pipeline
 
 ## Installation
 
+### For end users — Homebrew (macOS / Linux)
+
+```bash
+brew install edgesentry/tap/eds
+```
+
 ### For end users — pre-built binary
 
 Download the latest release from the [GitHub Releases page](https://github.com/edgesentry/edgesentry-rs/releases).

--- a/docs/inspect/en/src/cli.md
+++ b/docs/inspect/en/src/cli.md
@@ -6,6 +6,12 @@
 
 ## Installation
 
+### For end users — Homebrew (macOS / Linux)
+
+```bash
+brew install edgesentry/tap/eds
+```
+
 ### For end users — pre-built binary
 
 Download the latest release from the [GitHub Releases page](https://github.com/edgesentry/edgesentry-rs/releases).

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# update-homebrew-formula.sh — regenerate Formula/eds.rb for a given release tag
+# and push it to edgesentry/homebrew-tap.
+#
+# Usage:
+#   HOMEBREW_TAP_TOKEN=<pat> ./scripts/update-homebrew-formula.sh v1.2.3
+#
+# Requirements:
+#   - curl, sha256sum (or shasum on macOS), git
+#   - HOMEBREW_TAP_TOKEN env var with write access to edgesentry/homebrew-tap
+set -euo pipefail
+
+TAG_NAME="${1:?Usage: $0 <tag> (e.g. v1.2.3)}"
+GH_TOKEN="${HOMEBREW_TAP_TOKEN:?HOMEBREW_TAP_TOKEN must be set}"
+
+BASE_URL="https://github.com/edgesentry/edgesentry-rs/releases/download/${TAG_NAME}"
+MACOS_ASSET="eds-${TAG_NAME}-aarch64-apple-darwin.tar.gz"
+LINUX_ASSET="eds-${TAG_NAME}-x86_64-unknown-linux-gnu.tar.gz"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+cd "${WORK_DIR}"
+
+echo "Downloading release assets for ${TAG_NAME}..."
+curl -fsSL -o "${MACOS_ASSET}" "${BASE_URL}/${MACOS_ASSET}"
+curl -fsSL -o "${LINUX_ASSET}" "${BASE_URL}/${LINUX_ASSET}"
+
+# sha256sum on Linux; shasum -a 256 on macOS
+if command -v sha256sum &>/dev/null; then
+  SHA256_MACOS=$(sha256sum "${MACOS_ASSET}" | awk '{print $1}')
+  SHA256_LINUX=$(sha256sum "${LINUX_ASSET}" | awk '{print $1}')
+else
+  SHA256_MACOS=$(shasum -a 256 "${MACOS_ASSET}" | awk '{print $1}')
+  SHA256_LINUX=$(shasum -a 256 "${LINUX_ASSET}" | awk '{print $1}')
+fi
+
+echo "macOS SHA256 : ${SHA256_MACOS}"
+echo "Linux  SHA256: ${SHA256_LINUX}"
+
+cat > eds.rb <<FORMULA
+class Eds < Formula
+  desc "EdgeSentry unified CLI for tamper-evident audit and IFC scan inspection"
+  homepage "https://github.com/edgesentry/edgesentry-rs"
+  version "${TAG_NAME#v}"
+  license any_of: ["MIT", "Apache-2.0"]
+
+  on_macos do
+    on_arm do
+      url "${BASE_URL}/${MACOS_ASSET}"
+      sha256 "${SHA256_MACOS}"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "${BASE_URL}/${LINUX_ASSET}"
+      sha256 "${SHA256_LINUX}"
+    end
+  end
+
+  def install
+    bin.install "eds"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/eds --version")
+  end
+end
+FORMULA
+
+echo "Cloning edgesentry/homebrew-tap..."
+git clone "https://x-access-token:${GH_TOKEN}@github.com/edgesentry/homebrew-tap.git" tap
+mkdir -p tap/Formula
+cp eds.rb tap/Formula/eds.rb
+
+cd tap
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git config user.name "github-actions[bot]"
+git add Formula/eds.rb
+git commit -m "eds ${TAG_NAME}"
+git push
+
+echo "Formula/eds.rb updated in edgesentry/homebrew-tap for ${TAG_NAME}."


### PR DESCRIPTION
## Summary

- Reset workspace version from `0.3.0` → `0.1.3` (`0.2.0`/`0.3.0` release CI failed so neither shipped; this is the next version after the last successful release)
- Add `update_homebrew_tap` job to `release.yml` — uses a GitHub App token scoped to `homebrew-tap`, computes SHA256 checksums for macOS (aarch64) and Linux (x86_64) assets, and pushes `Formula/eds.rb` to `edgesentry/homebrew-tap`
- Add `scripts/update-homebrew-formula.sh` for manual tap updates (requires `HOMEBREW_TAP_TOKEN` env var)
- Document `brew install edgesentry/tap/eds` in both audit and inspect CLI docs

## Test plan

- [ ] Merge triggers release workflow and `update_homebrew_tap` job runs without error
- [ ] `Formula/eds.rb` in `edgesentry/homebrew-tap` is updated with correct version and SHA256 hashes
- [ ] `brew install edgesentry/tap/eds` installs the `eds` binary and `eds --version` returns `0.1.3`
- [ ] Manual script: `HOMEBREW_TAP_TOKEN=<pat> ./scripts/update-homebrew-formula.sh v0.1.3` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)