### PR TITLE
perf(ci): enable build artifact cache on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,7 @@ jobs:
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-registry-
 
-      - name: Cache build artifacts (non-Windows)
-        if: runner.os != 'Windows'
+      - name: Cache build artifacts
         uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
## Summary

- Remove `if: runner.os != 'Windows'` guard on the `Cache build artifacts` step in `ci.yml`
- The exclusion existed to work around path-handling bugs in `actions/cache` v2/v3 — fixed in v4 which the repo already uses
- Caching `~/.cargo/bin/` and `target/` on Windows eliminates the full recompile on every run, including the `ring` assembly build pulled in by `transport-mqtt-tls`

Expected improvement: Windows `Build and Test` from 10+ min → ~2 min (in line with macOS/Linux).

Closes #225

## Test plan

- [ ] Windows `Build and Test` job completes in under 5 minutes on a cached run
- [ ] Cache hit is shown in the `Cache build artifacts` step log on subsequent runs
- [ ] macOS and Linux jobs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)