### PR TITLE
sec: document RUSTSEC-2026-0049 exception in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,15 @@ ignore = [
   # available via upstream; upgrading requires rustls to drop the dep.
   # No direct call-site exposure in our code.
   { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile pulled in transitively by rustls 0.23 chain; no patch available. Functionality superseded by rustls-pki-types but not yet adopted by rustls." },
+  # RUSTSEC-2026-0049 / GHSA-pwjx-qhcg-rvj4: rustls-webpki CRL Distribution
+  # Point matching flaw (CVSS 4.4).  Patched in 0.103.10; no 0.102.x backport
+  # exists.  rumqttc 0.25.1 (latest, main branch) requires rustls-webpki ^0.102
+  # for its use-rustls-no-provider feature and has not updated this constraint.
+  # The TLS handshake itself uses rustls-webpki 0.103.10 via tokio-rustls 0.26;
+  # the 0.102.8 copy surfaces only as the WebPki error type in rumqttc.
+  # Exploitation requires a compromised trusted CA.  Unblock by upgrading rumqttc
+  # once it bumps rustls-webpki to ^0.103.
+  { id = "RUSTSEC-2026-0049", reason = "No 0.102.x patch for rustls-webpki; fix is in 0.103.10, which rumqttc 0.25.x does not yet accept (requires ^0.102). Tracking upstream." },
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

- Adds a documented `ignore` entry for `RUSTSEC-2026-0049` in `deny.toml`
- Dismisses Dependabot alert #4 with `tolerable_risk` reason

## Why there is no code fix

`rustls-webpki 0.102.8` is pulled in transitively by `rumqttc 0.25.1` via its `use-rustls-no-provider` feature (activated by our `transport-mqtt-tls` feature flag).

| What | Why no fix |
|------|-----------|
| No `0.102.x` backport | The patch landed in `0.103.10`; the `0.102` series received no fix |
| Semver incompatibility | `rumqttc` requires `rustls-webpki ^0.102`; `0.103.10` doesn't satisfy this |
| No upstream update | Both `rumqttc 0.25.1` (crates.io) and its `main` branch still require `^0.102` |

The vulnerable `0.102.8` copy is used only as the `WebPki` error type in `rumqttc`'s TLS error enum. The actual TLS handshake and certificate verification use `rustls-webpki 0.103.10` via `tokio-rustls 0.26`. Exploiting this requires compromising a trusted CA (CVSS 4.4).

## Unblock

Remove the `deny.toml` exception once `rumqttc` publishes a release that bumps `rustls-webpki` to `^0.103`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)