### PR TITLE
feat(inspect): IFC fetch from HTTP URL — remote source for scan pipeline (#251)

### DIFF
--- a/crates/edgesentry-inspect/Cargo.toml
+++ b/crates/edgesentry-inspect/Cargo.toml
@@ -28,9 +28,9 @@ glam = "0.32.1"
 image = { version = "0.25", default-features = false, features = ["png"] }
 toml = "0.8"
 ureq = "2"
+tempfile = "3"
 tract-onnx = "0.22"
 
 [dev-dependencies]
-tempfile = "3"
 mockito  = "1"
 tokio    = { version = "1", features = ["rt", "macros"] }

--- a/crates/edgesentry-inspect/config.example.toml
+++ b/crates/edgesentry-inspect/config.example.toml
@@ -3,8 +3,17 @@
 # Copy to config.toml and adjust paths before running:
 #   edgesentry-inspect scan --config config.toml
 
-# Path to the IFC design file (reference model).
+# IFC design file — choose one of the two options below.
+#
+# Option A — local file (default)
 ifc_path = "design.ifc"
+#
+# Option B — remote URL fetched before the pipeline runs (mutually exclusive with ifc_path).
+# The file is downloaded to a secure temp path; `ifc_path` is ignored when [ifc] is set.
+# Omit `token` for self-authenticating pre-signed S3 URLs.
+# [ifc]
+# url   = "https://bim.example.com/elements/E-001/ifc"
+# token = "eyJ..."   # optional Bearer token
 
 # Path to the as-built scan in ASCII PLY format.
 scan_path = "scan.ply"

--- a/crates/edgesentry-inspect/src/config.rs
+++ b/crates/edgesentry-inspect/src/config.rs
@@ -10,7 +10,17 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ScanConfig {
     /// Path to the IFC design file (reference model).
+    ///
+    /// Mutually exclusive with the `[ifc]` remote-URL section.
+    /// Defaults to an empty path when `[ifc]` is provided instead.
+    #[serde(default)]
     pub ifc_path: PathBuf,
+    /// Remote IFC source fetched via HTTPS before the pipeline runs.
+    ///
+    /// When set, `ifc_path` is ignored.  The IFC is downloaded to a secure
+    /// temp file and passed to the loader unchanged.
+    #[serde(default)]
+    pub ifc: Option<IfcUrlConfig>,
     /// Path to the scan point cloud (PLY, ASCII format).
     pub scan_path: PathBuf,
     /// Optional path to a pre-extracted `reference.json` mesh file.
@@ -92,6 +102,28 @@ pub struct OutputConfig {
 
 fn default_threshold() -> f64 {
     10.0
+}
+
+/// Remote IFC source — fetched from an HTTPS URL before the pipeline runs.
+///
+/// Supports optional Bearer-token authentication for BIM servers and
+/// self-authenticating pre-signed S3 URLs alike.
+///
+/// # Example (`config.toml`)
+///
+/// ```toml
+/// [ifc]
+/// url   = "https://bim.example.com/elements/E-001/ifc"
+/// token = "eyJ..."   # optional; omit for pre-signed URLs
+/// ```
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct IfcUrlConfig {
+    /// HTTPS URL of the IFC file (direct download or pre-signed S3 URL).
+    pub url: String,
+    /// Bearer token sent as `Authorization: Bearer <token>`.
+    /// Leave unset when using a self-authenticating pre-signed URL.
+    #[serde(default)]
+    pub token: Option<String>,
 }
 
 /// Parse a [`ScanConfig`] from a TOML file.

--- a/crates/edgesentry-inspect/src/ifc.rs
+++ b/crates/edgesentry-inspect/src/ifc.rs
@@ -3,7 +3,10 @@
 //! Parses `IFCCARTESIANPOINT` entries from an IFC file and returns them as a
 //! `Vec<Point3D>`. Only 3D points (three coordinate values) are included;
 //! 2D points are silently skipped.
+//!
+//! Remote IFC files can be fetched with [`fetch_ifc_url`] before loading.
 
+use std::io::Write as _;
 use std::path::Path;
 
 use trilink_core::Point3D;
@@ -16,6 +19,42 @@ pub enum IfcError {
 
     #[error("no 3D IFCCARTESIANPOINT entries found in file")]
     NoPoints,
+
+    #[error("HTTP fetch failed: {0}")]
+    Fetch(String),
+}
+
+/// Fetch an IFC file from `url` into a secure temp file and return it.
+///
+/// The [`tempfile::NamedTempFile`] is automatically deleted when dropped, so
+/// callers must keep it alive for as long as the path is needed.
+///
+/// # Authentication
+///
+/// Pass `token` to send `Authorization: Bearer <token>`.  Leave `None` for
+/// unauthenticated or self-authenticating pre-signed S3 URLs.
+pub fn fetch_ifc_url(url: &str, token: Option<&str>) -> Result<tempfile::NamedTempFile, IfcError> {
+    let resp = {
+        let req = ureq::get(url);
+        if let Some(t) = token {
+            req.set("Authorization", &format!("Bearer {t}"))
+        } else {
+            req
+        }
+        .call()
+        .map_err(|e| IfcError::Fetch(e.to_string()))?
+    };
+
+    let mut tmp = tempfile::Builder::new()
+        .prefix("edgesentry-ifc-")
+        .suffix(".ifc")
+        .tempfile()
+        .map_err(IfcError::Io)?;
+
+    std::io::copy(&mut resp.into_reader(), tmp.as_file_mut()).map_err(IfcError::Io)?;
+    tmp.flush().map_err(IfcError::Io)?;
+
+    Ok(tmp)
 }
 
 /// Load all 3-dimensional `IFCCARTESIANPOINT` entries from an IFC STEP-21 file.
@@ -100,5 +139,47 @@ END-ISO-10303-21;
     fn empty_file_returns_empty() {
         let pts = parse_ifc_points("ISO-10303-21;\nHEADER;\nENDSEC;\n");
         assert!(pts.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // fetch_ifc_url tests (require mockito)
+    // ------------------------------------------------------------------
+
+    const MINIMAL_IFC: &str = "#1= IFCCARTESIANPOINT((1.0,2.0,3.0));";
+
+    #[test]
+    fn fetch_ifc_url_downloads_content() {
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/wall.ifc")
+            .with_status(200)
+            .with_body(MINIMAL_IFC)
+            .create();
+
+        let tmp = fetch_ifc_url(&format!("{}/wall.ifc", server.url()), None).unwrap();
+        let content = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(content.trim(), MINIMAL_IFC);
+    }
+
+    #[test]
+    fn fetch_ifc_url_sends_bearer_token() {
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/wall.ifc")
+            .match_header("authorization", "Bearer test-token-abc")
+            .with_status(200)
+            .with_body(MINIMAL_IFC)
+            .create();
+
+        fetch_ifc_url(&format!("{}/wall.ifc", server.url()), Some("test-token-abc")).unwrap();
+    }
+
+    #[test]
+    fn fetch_ifc_url_404_returns_error() {
+        let mut server = mockito::Server::new();
+        let _m = server.mock("GET", "/missing.ifc").with_status(404).create();
+
+        let result = fetch_ifc_url(&format!("{}/missing.ifc", server.url()), None);
+        assert!(matches!(result, Err(IfcError::Fetch(_))));
     }
 }

--- a/crates/edgesentry-inspect/src/lib.rs
+++ b/crates/edgesentry-inspect/src/lib.rs
@@ -27,7 +27,7 @@ pub mod report;
 // Top-level re-exports — stable public API surface
 // ---------------------------------------------------------------------------
 
-pub use config::{CameraConfig, InferenceConfig, InferenceMode, OutputConfig, ScanConfig};
+pub use config::{CameraConfig, IfcUrlConfig, InferenceConfig, InferenceMode, OutputConfig, ScanConfig};
 pub use deviation::DeviationReport;
 pub use ingress::{FrameSource, SensorFrame};
 pub use pipeline::{run_scan, ScanError, ScanOutput};

--- a/crates/edgesentry-inspect/src/pipeline.rs
+++ b/crates/edgesentry-inspect/src/pipeline.rs
@@ -15,7 +15,7 @@ use crate::{
     config::{InferenceMode, ScanConfig},
     deviation::{compute_deviation, per_point_deviations_mm, DeviationReport},
     heatmap::{render_heatmap, write_heatmap_png},
-    ifc::load_ifc_points,
+    ifc::{fetch_ifc_url, load_ifc_points},
     inference::{depth_map_to_png, http_infer, mock_infer, onnx_infer, InferenceError},
     ply::{load_ply_points, PlyError},
     points::{write_points, PointsError, PointsJson},
@@ -77,8 +77,20 @@ pub enum ScanError {
 /// 9. Write `report.json`, `heatmap.png`, `points.json` (and optionally `reference.json`)
 pub fn run_scan(config: &ScanConfig) -> Result<ScanOutput, ScanError> {
     // Step 1 — IFC reference cloud
+    // Resolve the IFC source: remote URL (fetched to a temp file) or local path.
+    // `_ifc_tmp` must be kept alive here so the temp file is not deleted before loading.
+    let mut _ifc_tmp: Option<tempfile::NamedTempFile> = None;
+    let ifc_local_path: std::path::PathBuf = if let Some(url_cfg) = &config.ifc {
+        let tmp = fetch_ifc_url(&url_cfg.url, url_cfg.token.as_deref())
+            .map_err(|e| ScanError::Ifc(e.to_string()))?;
+        let path = tmp.path().to_owned();
+        _ifc_tmp = Some(tmp);
+        path
+    } else {
+        config.ifc_path.clone()
+    };
     let reference =
-        load_ifc_points(&config.ifc_path).map_err(|e| ScanError::Ifc(e.to_string()))?;
+        load_ifc_points(&ifc_local_path).map_err(|e| ScanError::Ifc(e.to_string()))?;
 
     // Step 2 — Scan point cloud
     let scan = load_ply_points(&config.scan_path)?;

--- a/crates/edgesentry-inspect/tests/fixtures_integration.rs
+++ b/crates/edgesentry-inspect/tests/fixtures_integration.rs
@@ -100,7 +100,7 @@ fn pipeline_detects_defect_in_generated_fixtures() {
 
     let out_dir = tmp.path().join("out");
     let cfg = ScanConfig {
-        ifc_path: tmp.path().join("wall_slab.ifc"),
+        ifc: None, ifc_path: tmp.path().join("wall_slab.ifc"),
         scan_path: tmp.path().join("wall_slab_scan.ply"),
         camera: CameraConfig {
             fx: 1280.0,

--- a/crates/edgesentry-inspect/tests/scan_pipeline_integration.rs
+++ b/crates/edgesentry-inspect/tests/scan_pipeline_integration.rs
@@ -53,7 +53,7 @@ fn scan_off_mode_produces_report_and_heatmap() {
     write_ply_points(&ply_path, &scan_pts).unwrap();
 
     let cfg = ScanConfig {
-        ifc_path: sample_ifc(),
+        ifc: None, ifc_path: sample_ifc(),
         scan_path: ply_path,
         camera: default_camera(),
         inference: InferenceConfig {
@@ -101,7 +101,7 @@ fn scan_zero_deviation_fully_compliant() {
     write_ply_points(&ply_path, &reference).unwrap();
 
     let cfg = ScanConfig {
-        ifc_path: sample_ifc(),
+        ifc: None, ifc_path: sample_ifc(),
         scan_path: ply_path,
         camera: default_camera(),
         inference: InferenceConfig {
@@ -131,7 +131,7 @@ fn scan_mock_mode_returns_one_detection_without_server() {
     write_ply_points(&ply_path, &scan_pts).unwrap();
 
     let cfg = ScanConfig {
-        ifc_path: sample_ifc(),
+        ifc: None, ifc_path: sample_ifc(),
         scan_path: ply_path,
         camera: default_camera(),
         inference: InferenceConfig {
@@ -169,7 +169,7 @@ fn scan_onnx_mode_detects_fixture_defect() {
     edgesentry_inspect::fixtures::generate_fixtures(fixture_dir.path()).unwrap();
 
     let cfg = edgesentry_inspect::config::ScanConfig {
-        ifc_path:  fixture_dir.path().join("wall_slab.ifc"),
+        ifc: None, ifc_path:  fixture_dir.path().join("wall_slab.ifc"),
         scan_path: fixture_dir.path().join("wall_slab_scan.ply"),
         camera: edgesentry_inspect::config::CameraConfig {
             fx: 1280.0, fy: 1080.0,
@@ -229,7 +229,7 @@ fn scan_http_mode_returns_detections() {
     let endpoint = format!("{}/detect", server.url());
 
     let cfg = ScanConfig {
-        ifc_path: sample_ifc(),
+        ifc: None, ifc_path: sample_ifc(),
         scan_path: ply_path,
         camera: default_camera(),
         inference: InferenceConfig {


### PR DESCRIPTION
## Summary

- Adds `fetch_ifc_url(url, token)` to `ifc.rs` — fetches IFC via HTTPS (ureq), optional `Authorization: Bearer` header, writes to a secure `NamedTempFile`
- Extends `ScanConfig` with optional `[ifc]` TOML section (`url` + `token`); when set, `ifc_path` is ignored
- `run_scan` resolves the IFC source before calling `load_ifc_points`, keeping the temp file alive for the duration of the pipeline
- Moves `tempfile` from dev-dependencies to regular dependencies
- Existing `ifc_path = "..."` configs unchanged — fully backwards compatible
- Closes #251

## Test plan

- [ ] Existing `ifc_path` tests pass unchanged (`cargo test -p edgesentry-inspect`)
- [ ] `fetch_ifc_url_downloads_content` — mockito verifies file contents written to temp file
- [ ] `fetch_ifc_url_sends_bearer_token` — mockito verifies `Authorization` header sent
- [ ] `fetch_ifc_url_404_returns_error` — HTTP error correctly mapped to `IfcError::Fetch`
- [ ] Doc-test compiles (config.example.toml parses as `ScanConfig`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)