### PR TITLE
feat: Phase 1 — migrate edgesentry-clarus engine into edgesentry-rs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,6 +1171,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "edgesentry-compute"
+version = "0.2.0"
+dependencies = [
+ "edgesentry-ingest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "edgesentry-evaluate"
+version = "0.2.0"
+dependencies = [
+ "edgesentry-compute",
+ "edgesentry-ingest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "edgesentry-ingest"
+version = "0.2.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "edgesentry-inspect"
 version = "0.2.0"
 dependencies = [
@@ -1191,16 +1219,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "edgesentry-profile"
+version = "0.2.0"
+dependencies = [
+ "edgesentry-evaluate",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "eds"
 version = "0.2.0"
 dependencies = [
  "clap",
  "ed25519-dalek",
  "edgesentry-audit",
+ "edgesentry-compute",
+ "edgesentry-evaluate",
+ "edgesentry-ingest",
  "edgesentry-inspect",
+ "edgesentry-profile",
  "hex",
  "rcgen",
  "reqwest",
+ "serde",
  "serde_json",
  "tokio",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ members = [
   "crates/edgesentry-audit",
   "crates/edgesentry-bridge",
   "crates/edgesentry-inspect",
+  "crates/edgesentry-ingest",
+  "crates/edgesentry-compute",
+  "crates/edgesentry-evaluate",
+  "crates/edgesentry-profile",
 ]
 resolver = "2"
 
@@ -24,3 +28,4 @@ serde_json = "1"
 hex = "0.4"
 rand = "0.8"
 tracing = "0.1"
+tempfile = "3"

--- a/crates/edgesentry-compute/Cargo.toml
+++ b/crates/edgesentry-compute/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "edgesentry-compute"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Physics and geometry computations — distance, TTC, zone membership"
+
+[dependencies]
+edgesentry-ingest = { path = "../edgesentry-ingest" }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/edgesentry-compute/src/lib.rs
+++ b/crates/edgesentry-compute/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod physics;
+pub use physics::*;

--- a/crates/edgesentry-compute/src/physics.rs
+++ b/crates/edgesentry-compute/src/physics.rs
@@ -1,0 +1,316 @@
+use edgesentry_ingest::entity::{Entity, EntityClass, Vec2};
+
+/// Straight-line distance between two entities in metres.
+pub fn euclidean_distance(a: &Entity, b: &Entity) -> f32 {
+    (&b.position - &a.position).length()
+}
+
+/// Rate at which entity `b` is closing with entity `a`, in m/s.
+///
+/// Positive  → approaching (gap is shrinking).
+/// Negative  → receding.
+/// Zero      → perpendicular movement or identical velocities.
+pub fn relative_velocity(a: &Entity, b: &Entity) -> f32 {
+    let direction = &b.position - &a.position;
+    if direction.length() < f32::EPSILON {
+        return 0.0;
+    }
+    let unit = direction.normalize();
+    // Project a's velocity onto the approach axis; subtract b's component.
+    let rel = &a.velocity - &b.velocity;
+    rel.dot(&unit)
+}
+
+/// Minimum stopping distance at `speed_ms` (m/s) for the given entity class, in metres.
+///
+/// Uses kinematic formula: d = v² / (2a).
+/// Person is modelled as stopping instantly (returns 0.0 — conservative).
+pub fn braking_distance(speed_ms: f32, entity_class: &EntityClass) -> f32 {
+    let decel = entity_class.deceleration_ms2();
+    if decel == f32::INFINITY {
+        return 0.0; // Person: instant stop
+    }
+    if decel <= 0.0 || speed_ms <= 0.0 {
+        return 0.0;
+    }
+    (speed_ms * speed_ms) / (2.0 * decel)
+}
+
+/// Time to collision given current gap and approach rate, in seconds.
+///
+/// Returns `f32::INFINITY` when entities are not approaching.
+pub fn time_to_collision(distance_m: f32, approach_rate_ms: f32) -> f32 {
+    if approach_rate_ms <= 0.0 {
+        return f32::INFINITY;
+    }
+    distance_m / approach_rate_ms
+}
+
+/// Returns `true` if `pos` lies inside the polygon defined by `vertices`.
+///
+/// Uses the ray-casting algorithm. The polygon is treated as closed
+/// (last vertex implicitly connects back to the first).
+/// Returns `false` for degenerate polygons with fewer than 3 vertices.
+pub fn zone_membership(pos: Vec2, polygon: &[Vec2]) -> bool {
+    let n = polygon.len();
+    if n < 3 {
+        return false;
+    }
+    let mut inside = false;
+    let mut j = n - 1;
+    for i in 0..n {
+        let vi = &polygon[i];
+        let vj = &polygon[j];
+        let crosses_y = (vi.y > pos.y) != (vj.y > pos.y);
+        let x_intersect = (vj.x - vi.x) * (pos.y - vi.y) / (vj.y - vi.y) + vi.x;
+        if crosses_y && pos.x < x_intersect {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use edgesentry_ingest::entity::{Entity, EntityClass, Vec2};
+
+    fn entity(x: f32, y: f32, vx: f32, vy: f32) -> Entity {
+        Entity {
+            id: "t".into(),
+            class: EntityClass::Forklift,
+            position: Vec2::new(x, y),
+            velocity: Vec2::new(vx, vy),
+            timestamp_ms: 0,
+        }
+    }
+
+    // ── euclidean_distance ────────────────────────────────────────────────
+
+    #[test]
+    fn distance_3_4_5_triangle() {
+        let a = entity(0.0, 0.0, 0.0, 0.0);
+        let b = entity(3.0, 4.0, 0.0, 0.0);
+        assert!((euclidean_distance(&a, &b) - 5.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn distance_same_position_is_zero() {
+        let a = entity(2.0, 3.0, 0.0, 0.0);
+        assert!((euclidean_distance(&a, &a)).abs() < 1e-5);
+    }
+
+    // ── relative_velocity ─────────────────────────────────────────────────
+
+    #[test]
+    fn approaching_head_on() {
+        // a moves right at 2 m/s toward stationary b at x=10
+        let a = entity(0.0, 0.0, 2.0, 0.0);
+        let b = entity(10.0, 0.0, 0.0, 0.0);
+        let rv = relative_velocity(&a, &b);
+        assert!((rv - 2.0).abs() < 1e-4, "got {rv}");
+    }
+
+    #[test]
+    fn receding_is_negative() {
+        let a = entity(0.0, 0.0, -2.0, 0.0);
+        let b = entity(10.0, 0.0, 0.0, 0.0);
+        assert!(relative_velocity(&a, &b) < 0.0);
+    }
+
+    #[test]
+    fn perpendicular_motion_is_zero() {
+        // a moves up, b is to the right — no approach component
+        let a = entity(0.0, 0.0, 0.0, 2.0);
+        let b = entity(10.0, 0.0, 0.0, 0.0);
+        let rv = relative_velocity(&a, &b);
+        assert!(rv.abs() < 1e-4, "got {rv}");
+    }
+
+    #[test]
+    fn same_position_returns_zero() {
+        let a = entity(5.0, 5.0, 1.0, 0.0);
+        let b = entity(5.0, 5.0, 0.0, 0.0);
+        assert_eq!(relative_velocity(&a, &b), 0.0);
+    }
+
+    // ── braking_distance ─────────────────────────────────────────────────
+
+    #[test]
+    fn forklift_10kmh() {
+        // 10 km/h = 2.778 m/s, decel = 1.5 m/s² → d = 7.716/3.0 ≈ 2.572 m
+        let d = braking_distance(2.778, &EntityClass::Forklift);
+        assert!((d - 2.572).abs() < 0.01, "got {d}");
+    }
+
+    #[test]
+    fn person_stops_instantly() {
+        assert_eq!(braking_distance(1.5, &EntityClass::Person), 0.0);
+    }
+
+    #[test]
+    fn zero_speed_is_zero_distance() {
+        assert_eq!(braking_distance(0.0, &EntityClass::Forklift), 0.0);
+    }
+
+    #[test]
+    fn vessel_long_stopping_distance() {
+        // Vessel at 3 knots ≈ 1.54 m/s, decel = 0.05 m/s² → d ≈ 23.7 m
+        let d = braking_distance(1.54, &EntityClass::Vessel);
+        assert!(d > 20.0, "expected >20 m, got {d}");
+    }
+
+    // ── time_to_collision ─────────────────────────────────────────────────
+
+    #[test]
+    fn ttc_basic() {
+        assert!((time_to_collision(10.0, 5.0) - 2.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn ttc_not_approaching_is_infinity() {
+        assert_eq!(time_to_collision(10.0, 0.0), f32::INFINITY);
+        assert_eq!(time_to_collision(10.0, -1.0), f32::INFINITY);
+    }
+
+    // ── zone_membership ───────────────────────────────────────────────────
+
+    fn unit_square() -> Vec<Vec2> {
+        vec![
+            Vec2::new(0.0, 0.0),
+            Vec2::new(10.0, 0.0),
+            Vec2::new(10.0, 10.0),
+            Vec2::new(0.0, 10.0),
+        ]
+    }
+
+    #[test]
+    fn centre_is_inside() {
+        assert!(zone_membership(Vec2::new(5.0, 5.0), &unit_square()));
+    }
+
+    #[test]
+    fn outside_is_false() {
+        assert!(!zone_membership(Vec2::new(15.0, 5.0), &unit_square()));
+        assert!(!zone_membership(Vec2::new(-1.0, 5.0), &unit_square()));
+    }
+
+    #[test]
+    fn degenerate_polygon_is_false() {
+        let poly = vec![Vec2::new(0.0, 0.0), Vec2::new(1.0, 0.0)];
+        assert!(!zone_membership(Vec2::new(0.5, 0.0), &poly));
+    }
+
+    #[test]
+    fn triangle_inside_and_outside() {
+        // Right triangle with vertices (0,0), (10,0), (0,10)
+        let tri = vec![
+            Vec2::new(0.0, 0.0),
+            Vec2::new(10.0, 0.0),
+            Vec2::new(0.0, 10.0),
+        ];
+        assert!(zone_membership(Vec2::new(1.0, 1.0), &tri));
+        assert!(!zone_membership(Vec2::new(8.0, 8.0), &tri));
+    }
+
+    #[test]
+    fn empty_polygon_is_false() {
+        assert!(!zone_membership(Vec2::new(0.0, 0.0), &[]));
+    }
+
+    // ── Edge cases ────────────────────────────────────────────────────────
+
+    #[test]
+    fn both_entities_moving_toward_each_other() {
+        // a at 0 moving right at 1, b at 10 moving left at 1 → approach rate = 2
+        let a = entity(0.0, 0.0, 1.0, 0.0);
+        let b = entity(10.0, 0.0, -1.0, 0.0);
+        let rv = relative_velocity(&a, &b);
+        assert!((rv - 2.0).abs() < 1e-4, "got {rv}");
+    }
+
+    #[test]
+    fn both_entities_moving_same_direction_same_speed() {
+        let a = entity(0.0, 0.0, 2.0, 0.0);
+        let b = entity(10.0, 0.0, 2.0, 0.0);
+        // No closing speed — parallel movement
+        let rv = relative_velocity(&a, &b);
+        assert!(rv.abs() < 1e-4, "got {rv}");
+    }
+
+    #[test]
+    fn distance_is_symmetric() {
+        let a = entity(1.0, 2.0, 0.0, 0.0);
+        let b = entity(4.0, 6.0, 0.0, 0.0);
+        assert!((euclidean_distance(&a, &b) - euclidean_distance(&b, &a)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn braking_distance_reach_stacker_vs_forklift() {
+        // Reach stacker decelerates slower → longer stopping distance at same speed
+        let speed = 3.0;
+        let forklift = braking_distance(speed, &EntityClass::Forklift);
+        let stacker = braking_distance(speed, &EntityClass::ReachStacker);
+        assert!(stacker > forklift, "stacker {stacker} should be > forklift {forklift}");
+    }
+
+    #[test]
+    fn ttc_scales_with_distance() {
+        // Double the distance → double the TTC
+        let ttc_near = time_to_collision(5.0, 2.5);
+        let ttc_far = time_to_collision(10.0, 2.5);
+        assert!((ttc_far - 2.0 * ttc_near).abs() < 1e-5);
+    }
+
+    // ── Realistic scenario: MPA clearance breach ──────────────────────────
+    //
+    // Forklift FL-01 at (0, 0) moving toward Worker W-03 at (3.2, 0) at 1.4 m/s.
+    // A typical site safety rule requires ≥ 5.0 m clearance.
+    //
+    // Expected outputs from the roadmap demo:
+    //   distance          = 3.2 m   (< 5.0 m threshold → rule fires)
+    //   approach_rate     ≈ 1.4 m/s
+    //   braking_distance  ≈ 0.65 m  (at 1.4 m/s, Forklift decel 1.5 m/s²)
+    //   TTC               ≈ 2.3 s
+
+    #[test]
+    fn scenario_mpa_clearance_breach_distance() {
+        let forklift = entity(0.0, 0.0, 1.4, 0.0);
+        let worker = entity(3.2, 0.0, 0.0, 0.0);
+        let dist = euclidean_distance(&forklift, &worker);
+        assert!((dist - 3.2).abs() < 1e-4);
+        assert!(dist < 5.0, "clearance {dist}m breaches 5.0m threshold");
+    }
+
+    #[test]
+    fn scenario_mpa_clearance_breach_approach_rate() {
+        let forklift = entity(0.0, 0.0, 1.4, 0.0);
+        let worker = entity(3.2, 0.0, 0.0, 0.0);
+        let rv = relative_velocity(&forklift, &worker);
+        assert!((rv - 1.4).abs() < 1e-4, "approach rate {rv} m/s");
+    }
+
+    #[test]
+    fn scenario_mpa_clearance_breach_ttc() {
+        // distance=3.2m, approach_rate=1.4 m/s → TTC = 3.2/1.4 ≈ 2.286 s
+        let ttc = time_to_collision(3.2, 1.4);
+        assert!((ttc - 2.286).abs() < 0.01, "TTC {ttc} s");
+    }
+
+    #[test]
+    fn scenario_mpa_clearance_breach_braking_distance() {
+        // At 1.4 m/s with decel 1.5 m/s²: d = 1.96/3.0 ≈ 0.653 m
+        let bd = braking_distance(1.4, &EntityClass::Forklift);
+        assert!((bd - 0.653).abs() < 0.01, "braking distance {bd} m");
+    }
+
+    #[test]
+    fn scenario_safe_pass_no_breach() {
+        // Forklift passes at 6.0 m clearance — above the 5.0 m threshold, no rule fire
+        let forklift = entity(0.0, 0.0, 1.0, 0.0);
+        let worker = entity(6.0, 0.0, 0.0, 0.0);
+        let dist = euclidean_distance(&forklift, &worker);
+        assert!(dist >= 5.0, "6 m clearance should not breach 5 m threshold");
+    }
+}

--- a/crates/edgesentry-evaluate/Cargo.toml
+++ b/crates/edgesentry-evaluate/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "edgesentry-evaluate"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Rule DSL and evaluation engine — loads rules.json and evaluates RiskEvents"
+
+[dependencies]
+edgesentry-ingest = { path = "../edgesentry-ingest" }
+edgesentry-compute = { path = "../edgesentry-compute" }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/edgesentry-evaluate/src/lib.rs
+++ b/crates/edgesentry-evaluate/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod rules;
+pub use rules::*;

--- a/crates/edgesentry-evaluate/src/rules.rs
+++ b/crates/edgesentry-evaluate/src/rules.rs
@@ -1,0 +1,412 @@
+use serde::Deserialize;
+
+use edgesentry_ingest::entity::{Entity, Vec2};
+use edgesentry_compute::{euclidean_distance, relative_velocity, time_to_collision, zone_membership};
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Deserialize, serde::Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum Severity {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
+
+/// A evaluated condition type, parsed from the `condition` string in rules.json.
+#[derive(Debug, Clone)]
+pub enum Condition {
+    /// Fire when the distance between any two entities drops below threshold (metres).
+    DistanceLt(f32),
+    /// Fire when the time-to-collision between any two approaching entities drops below threshold (s).
+    TtcLt(f32),
+    /// Fire when any entity's position is inside the given polygon.
+    ZoneMember(Vec<Vec2>),
+}
+
+#[derive(Debug, Clone)]
+pub struct Rule {
+    pub rule_id: String,
+    pub condition: Condition,
+    pub severity: Severity,
+    pub regulation: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RiskEvent {
+    pub rule_id: String,
+    pub severity: Severity,
+    /// Exact regulation clause that was violated.
+    pub regulation: String,
+    /// IDs of the entities involved (two for proximity/TTC rules, one for zone rules).
+    pub entity_ids: Vec<String>,
+    /// The physical measurement that triggered the event (distance in m, TTC in s, or 1.0 for zone).
+    pub measured_value: f32,
+    /// The threshold that was breached.
+    pub threshold: f32,
+    pub timestamp_ms: u64,
+}
+
+// ── JSON loading ──────────────────────────────────────────────────────────────
+
+/// Raw rule as it appears in rules.json — condition is still a string.
+#[derive(Debug, Deserialize)]
+struct RuleJson {
+    rule_id: String,
+    condition: String,
+    severity: Severity,
+    regulation: String,
+    /// Required for `zone_member` conditions; polygon vertices as [x, y] pairs.
+    zone: Option<Vec<[f32; 2]>>,
+}
+
+/// Load and parse rules from a JSON string (contents of rules.json).
+///
+/// # Errors
+/// Returns an error string if the JSON is malformed or a condition cannot be parsed.
+pub fn load_rules(json: &str) -> Result<Vec<Rule>, String> {
+    let raws: Vec<RuleJson> =
+        serde_json::from_str(json).map_err(|e| format!("JSON parse error: {e}"))?;
+    raws.into_iter().map(rule_from_json).collect()
+}
+
+fn rule_from_json(raw: RuleJson) -> Result<Rule, String> {
+    let condition = parse_condition(&raw.condition, raw.zone)?;
+    Ok(Rule {
+        rule_id: raw.rule_id,
+        condition,
+        severity: raw.severity,
+        regulation: raw.regulation,
+    })
+}
+
+fn parse_condition(s: &str, zone: Option<Vec<[f32; 2]>>) -> Result<Condition, String> {
+    let s = s.trim();
+    if s == "zone_member" {
+        let verts = zone.ok_or_else(|| {
+            "condition 'zone_member' requires a 'zone' polygon in the rule".to_string()
+        })?;
+        let polygon = verts.into_iter().map(|[x, y]| Vec2::new(x, y)).collect();
+        return Ok(Condition::ZoneMember(polygon));
+    }
+    if let Some(rest) = s.strip_prefix("distance < ") {
+        let t: f32 = rest.trim().parse().map_err(|_| format!("invalid threshold in '{s}'"))?;
+        return Ok(Condition::DistanceLt(t));
+    }
+    if let Some(rest) = s.strip_prefix("ttc < ") {
+        let t: f32 = rest.trim().parse().map_err(|_| format!("invalid threshold in '{s}'"))?;
+        return Ok(Condition::TtcLt(t));
+    }
+    Err(format!("unknown condition expression: '{s}'"))
+}
+
+// ── Evaluation ────────────────────────────────────────────────────────────────
+
+/// Evaluate all rules against the current entity snapshot.
+/// Returns one `RiskEvent` per (rule, entity-pair or entity) that breaches a threshold.
+pub fn evaluate(rules: &[Rule], entities: &[Entity], timestamp_ms: u64) -> Vec<RiskEvent> {
+    let mut events = Vec::new();
+
+    for rule in rules {
+        match &rule.condition {
+            Condition::DistanceLt(threshold) => {
+                for i in 0..entities.len() {
+                    for j in (i + 1)..entities.len() {
+                        let dist = euclidean_distance(&entities[i], &entities[j]);
+                        if dist < *threshold {
+                            events.push(RiskEvent {
+                                rule_id: rule.rule_id.clone(),
+                                severity: rule.severity.clone(),
+                                regulation: rule.regulation.clone(),
+                                entity_ids: vec![
+                                    entities[i].id.clone(),
+                                    entities[j].id.clone(),
+                                ],
+                                measured_value: dist,
+                                threshold: *threshold,
+                                timestamp_ms,
+                            });
+                        }
+                    }
+                }
+            }
+            Condition::TtcLt(threshold) => {
+                for i in 0..entities.len() {
+                    for j in (i + 1)..entities.len() {
+                        let dist = euclidean_distance(&entities[i], &entities[j]);
+                        let rv = relative_velocity(&entities[i], &entities[j]);
+                        let ttc = time_to_collision(dist, rv);
+                        if ttc < *threshold {
+                            events.push(RiskEvent {
+                                rule_id: rule.rule_id.clone(),
+                                severity: rule.severity.clone(),
+                                regulation: rule.regulation.clone(),
+                                entity_ids: vec![
+                                    entities[i].id.clone(),
+                                    entities[j].id.clone(),
+                                ],
+                                measured_value: ttc,
+                                threshold: *threshold,
+                                timestamp_ms,
+                            });
+                        }
+                    }
+                }
+            }
+            Condition::ZoneMember(polygon) => {
+                for entity in entities {
+                    if zone_membership(entity.position.clone(), polygon) {
+                        events.push(RiskEvent {
+                            rule_id: rule.rule_id.clone(),
+                            severity: rule.severity.clone(),
+                            regulation: rule.regulation.clone(),
+                            entity_ids: vec![entity.id.clone()],
+                            measured_value: 1.0,
+                            threshold: 0.0,
+                            timestamp_ms,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    events
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use edgesentry_ingest::entity::{Entity, EntityClass, Vec2};
+
+    fn entity(id: &str, x: f32, y: f32, vx: f32, vy: f32) -> Entity {
+        Entity {
+            id: id.into(),
+            class: EntityClass::Forklift,
+            position: Vec2::new(x, y),
+            velocity: Vec2::new(vx, vy),
+            timestamp_ms: 0,
+        }
+    }
+
+    const DEMO_RULES_JSON: &str = r#"[
+        {"rule_id":"PROXIMITY_ALERT","condition":"distance < 5.0","severity":"HIGH","regulation":"Site Safety Procedure §3.1"},
+        {"rule_id":"EXCLUSION_ZONE_BREACH","condition":"zone_member","severity":"CRITICAL","regulation":"Site Safety Procedure §4.1","zone":[[0,0],[10,0],[10,10],[0,10]]},
+        {"rule_id":"TTC_ALERT","condition":"ttc < 3.0","severity":"HIGH","regulation":"Site Safety Procedure §3.2"}
+    ]"#;
+
+    // ── load_rules ────────────────────────────────────────────────────────
+
+    #[test]
+    fn load_parses_three_rules() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        assert_eq!(rules.len(), 3);
+    }
+
+    #[test]
+    fn load_rule_ids_correct() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        assert_eq!(rules[0].rule_id, "PROXIMITY_ALERT");
+        assert_eq!(rules[1].rule_id, "EXCLUSION_ZONE_BREACH");
+        assert_eq!(rules[2].rule_id, "TTC_ALERT");
+    }
+
+    #[test]
+    fn load_severities_correct() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        assert_eq!(rules[0].severity, Severity::High);
+        assert_eq!(rules[1].severity, Severity::Critical);
+    }
+
+    #[test]
+    fn load_condition_distance_threshold() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        match &rules[0].condition {
+            Condition::DistanceLt(t) => assert!((*t - 5.0).abs() < 1e-5),
+            other => panic!("expected DistanceLt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_condition_zone_has_polygon() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        match &rules[1].condition {
+            Condition::ZoneMember(polygon) => assert_eq!(polygon.len(), 4),
+            other => panic!("expected ZoneMember, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_condition_ttc_threshold() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        match &rules[2].condition {
+            Condition::TtcLt(t) => assert!((*t - 3.0).abs() < 1e-5),
+            other => panic!("expected TtcLt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn load_invalid_json_returns_error() {
+        assert!(load_rules("{not json}").is_err());
+    }
+
+    #[test]
+    fn load_zone_member_without_zone_returns_error() {
+        let json = r#"[{"rule_id":"X","condition":"zone_member","severity":"HIGH","regulation":"r"}]"#;
+        assert!(load_rules(json).is_err());
+    }
+
+    #[test]
+    fn load_unknown_condition_returns_error() {
+        let json = r#"[{"rule_id":"X","condition":"unknown_op > 5","severity":"HIGH","regulation":"r"}]"#;
+        assert!(load_rules(json).is_err());
+    }
+
+    // ── evaluate — distance ───────────────────────────────────────────────
+
+    #[test]
+    fn evaluate_distance_breach_fires_event() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, 1.4, 0.0),
+            entity("W-03", 3.2, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 1000);
+        let evt = events.iter().find(|e| e.rule_id == "PROXIMITY_ALERT").unwrap();
+        assert!((evt.measured_value - 3.2).abs() < 1e-4);
+        assert_eq!(evt.threshold, 5.0);
+        assert_eq!(evt.entity_ids, vec!["FL-01", "W-03"]);
+        assert_eq!(evt.timestamp_ms, 1000);
+    }
+
+    #[test]
+    fn evaluate_distance_no_breach_when_safe() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, 0.0, 0.0),
+            entity("W-03", 6.0, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 0);
+        assert!(!events.iter().any(|e| e.rule_id == "PROXIMITY_ALERT"));
+    }
+
+    #[test]
+    fn evaluate_distance_multiple_pairs() {
+        // Three entities, two pairs breach clearance
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        let entities = vec![
+            entity("A", 0.0, 0.0, 0.0, 0.0),
+            entity("B", 1.0, 0.0, 0.0, 0.0), // A-B: 1m → breach
+            entity("C", 2.0, 0.0, 0.0, 0.0), // A-C: 2m → breach; B-C: 1m → breach
+        ];
+        let events: Vec<_> = evaluate(&rules, &entities, 0)
+            .into_iter()
+            .filter(|e| e.rule_id == "PROXIMITY_ALERT")
+            .collect();
+        assert_eq!(events.len(), 3);
+    }
+
+    // ── evaluate — zone ───────────────────────────────────────────────────
+
+    #[test]
+    fn evaluate_zone_breach_fires_for_entity_inside() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        let entities = vec![entity("V-01", 5.0, 5.0, 0.0, 0.0)]; // inside [0,0]-[10,10]
+        let events = evaluate(&rules, &entities, 0);
+        assert!(events.iter().any(|e| e.rule_id == "EXCLUSION_ZONE_BREACH"));
+    }
+
+    #[test]
+    fn evaluate_zone_no_breach_when_outside() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        let entities = vec![entity("V-01", 15.0, 5.0, 0.0, 0.0)]; // outside zone
+        let events = evaluate(&rules, &entities, 0);
+        assert!(!events.iter().any(|e| e.rule_id == "EXCLUSION_ZONE_BREACH"));
+    }
+
+    // ── evaluate — TTC ────────────────────────────────────────────────────
+
+    #[test]
+    fn evaluate_ttc_breach_fires_when_fast_approach() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        // 2m gap, 5 m/s approach → TTC = 0.4 s < 3.0 s
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, 5.0, 0.0),
+            entity("W-03", 2.0, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 0);
+        assert!(events.iter().any(|e| e.rule_id == "TTC_ALERT"));
+    }
+
+    #[test]
+    fn evaluate_ttc_no_breach_when_slow_approach() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        // 20m gap, 1 m/s approach → TTC = 20 s > 3.0 s
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, 1.0, 0.0),
+            entity("W-03", 20.0, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 0);
+        assert!(!events.iter().any(|e| e.rule_id == "TTC_ALERT"));
+    }
+
+    #[test]
+    fn evaluate_ttc_no_breach_when_receding() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        // Moving away — TTC = ∞
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, -3.0, 0.0),
+            entity("W-03", 2.0, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 0);
+        assert!(!events.iter().any(|e| e.rule_id == "TTC_ALERT"));
+    }
+
+    // ── evaluate — empty inputs ───────────────────────────────────────────
+
+    #[test]
+    fn evaluate_empty_entities_returns_no_events() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        assert!(evaluate(&rules, &[], 0).is_empty());
+    }
+
+    #[test]
+    fn evaluate_empty_rules_returns_no_events() {
+        let entities = vec![entity("A", 0.0, 0.0, 1.0, 0.0)];
+        assert!(evaluate(&[], &entities, 0).is_empty());
+    }
+
+    // ── Scenario: roadmap demo ────────────────────────────────────────────
+    // Forklift FL-01 at (0,0) moving at 1.4 m/s toward Worker W-03 at (3.2,0).
+    // Expects PROXIMITY_ALERT and TTC_ALERT to fire.
+
+    #[test]
+    fn scenario_roadmap_demo_fires_clearance_and_ttc() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, 1.4, 0.0),
+            entity("W-03", 3.2, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 14230000);
+        let rule_ids: Vec<&str> = events.iter().map(|e| e.rule_id.as_str()).collect();
+        assert!(rule_ids.contains(&"PROXIMITY_ALERT"), "clearance rule should fire");
+        assert!(rule_ids.contains(&"TTC_ALERT"), "TTC rule should fire");
+    }
+
+    #[test]
+    fn scenario_roadmap_demo_clearance_event_values() {
+        let rules = load_rules(DEMO_RULES_JSON).unwrap();
+        let entities = vec![
+            entity("FL-01", 0.0, 0.0, 1.4, 0.0),
+            entity("W-03", 3.2, 0.0, 0.0, 0.0),
+        ];
+        let events = evaluate(&rules, &entities, 14230000);
+        let evt = events.iter().find(|e| e.rule_id == "PROXIMITY_ALERT").unwrap();
+        assert!((evt.measured_value - 3.2).abs() < 1e-4);
+        assert_eq!(evt.severity, Severity::High);
+        assert!(evt.regulation.contains("§3.1"));
+    }
+}

--- a/crates/edgesentry-ingest/Cargo.toml
+++ b/crates/edgesentry-ingest/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "edgesentry-ingest"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Structured data ingestion — CSV replay, entity stream, PLY/IFC loaders"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/edgesentry-ingest/src/csv_replay.rs
+++ b/crates/edgesentry-ingest/src/csv_replay.rs
@@ -1,0 +1,173 @@
+use crate::entity::{Entity, EntityClass, Vec2};
+
+/// A single time-slice of entity positions.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct EntityFrame {
+    pub timestamp_ms: u64,
+    pub entities: Vec<Entity>,
+}
+
+/// Replay entities from a CSV file.
+///
+/// CSV columns: `id,class,x,y,vx,vy,timestamp_ms`
+pub struct FileReplayAdapter {
+    frames: Vec<EntityFrame>,
+    cursor: usize,
+}
+
+impl FileReplayAdapter {
+    /// Load from a CSV file.  Header row is required and must match exactly:
+    /// `id,class,x,y,vx,vy,timestamp_ms`
+    pub fn from_csv(content: &str) -> Result<Self, String> {
+        let mut lines = content.lines();
+        let header = lines.next().ok_or("empty file")?;
+        if header.trim() != "id,class,x,y,vx,vy,timestamp_ms" {
+            return Err(format!("unexpected CSV header: {header}"));
+        }
+
+        let mut frames_map: std::collections::BTreeMap<u64, Vec<Entity>> =
+            std::collections::BTreeMap::new();
+
+        for (i, line) in lines.enumerate() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let cols: Vec<&str> = line.splitn(7, ',').collect();
+            if cols.len() != 7 {
+                return Err(format!("line {}: expected 7 columns, got {}", i + 2, cols.len()));
+            }
+            let id = cols[0].to_string();
+            let class: EntityClass = serde_json::from_value(serde_json::Value::String(
+                cols[1].to_string(),
+            ))
+            .map_err(|_| format!("line {}: unknown class '{}'", i + 2, cols[1]))?;
+            let x: f32 = cols[2].parse().map_err(|_| format!("line {}: bad x", i + 2))?;
+            let y: f32 = cols[3].parse().map_err(|_| format!("line {}: bad y", i + 2))?;
+            let vx: f32 = cols[4].parse().map_err(|_| format!("line {}: bad vx", i + 2))?;
+            let vy: f32 = cols[5].parse().map_err(|_| format!("line {}: bad vy", i + 2))?;
+            let ts: u64 = cols[6].parse().map_err(|_| format!("line {}: bad timestamp", i + 2))?;
+
+            frames_map.entry(ts).or_default().push(Entity {
+                id,
+                class,
+                position: Vec2::new(x, y),
+                velocity: Vec2::new(vx, vy),
+                timestamp_ms: ts,
+            });
+        }
+
+        let frames = frames_map
+            .into_iter()
+            .map(|(ts, entities)| EntityFrame { timestamp_ms: ts, entities })
+            .collect();
+
+        Ok(Self { frames, cursor: 0 })
+    }
+
+    /// Return the next frame as a `Vec<Entity>`, or `None` when all frames have been replayed.
+    pub fn next_frame(&mut self) -> Option<Vec<Entity>> {
+        if self.cursor >= self.frames.len() {
+            return None;
+        }
+        let frame = self.frames[self.cursor].entities.clone();
+        self.cursor += 1;
+        Some(frame)
+    }
+
+    /// Return a slice of all `EntityFrame`s.
+    pub fn frames(&self) -> &[EntityFrame] {
+        &self.frames
+    }
+
+    /// Reset replay to the beginning.
+    #[allow(dead_code)]
+    pub fn reset(&mut self) {
+        self.cursor = 0;
+    }
+
+    pub fn frame_count(&self) -> usize {
+        self.frames.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_CSV: &str = "id,class,x,y,vx,vy,timestamp_ms\n\
+FL-01,Forklift,0.0,0.0,1.4,0.0,1000\n\
+W-03,Person,3.2,0.0,0.0,0.0,1000\n\
+FL-01,Forklift,0.14,0.0,1.4,0.0,2000\n";
+
+    #[test]
+    fn loads_two_frames() {
+        let adapter = FileReplayAdapter::from_csv(SAMPLE_CSV).unwrap();
+        assert_eq!(adapter.frame_count(), 2);
+    }
+
+    #[test]
+    fn first_frame_has_two_entities() {
+        let mut adapter = FileReplayAdapter::from_csv(SAMPLE_CSV).unwrap();
+        let frame = adapter.next_frame().unwrap();
+        assert_eq!(frame.len(), 2);
+    }
+
+    #[test]
+    fn entity_fields_parsed_correctly() {
+        let mut adapter = FileReplayAdapter::from_csv(SAMPLE_CSV).unwrap();
+        let frame = adapter.next_frame().unwrap();
+        let fl = frame.iter().find(|e| e.id == "FL-01").unwrap();
+        assert_eq!(fl.class, crate::entity::EntityClass::Forklift);
+        assert!((fl.velocity.x - 1.4).abs() < 1e-5);
+        assert_eq!(fl.timestamp_ms, 1000);
+    }
+
+    #[test]
+    fn returns_none_after_all_frames() {
+        let mut adapter = FileReplayAdapter::from_csv(SAMPLE_CSV).unwrap();
+        adapter.next_frame();
+        adapter.next_frame();
+        assert!(adapter.next_frame().is_none());
+    }
+
+    #[test]
+    fn reset_replays_from_start() {
+        let mut adapter = FileReplayAdapter::from_csv(SAMPLE_CSV).unwrap();
+        adapter.next_frame();
+        adapter.next_frame();
+        adapter.reset();
+        assert!(adapter.next_frame().is_some());
+    }
+
+    #[test]
+    fn bad_header_returns_error() {
+        let result = FileReplayAdapter::from_csv("wrong,header\n1,2\n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn unknown_class_returns_error() {
+        let csv = "id,class,x,y,vx,vy,timestamp_ms\nX,Submarine,0,0,0,0,0\n";
+        assert!(FileReplayAdapter::from_csv(csv).is_err());
+    }
+
+    #[test]
+    fn frames_accessor_returns_all_frames() {
+        let adapter = FileReplayAdapter::from_csv(SAMPLE_CSV).unwrap();
+        let frames = adapter.frames();
+        assert_eq!(frames.len(), 2);
+        assert_eq!(frames[0].timestamp_ms, 1000);
+        assert_eq!(frames[1].timestamp_ms, 2000);
+    }
+
+    #[test]
+    fn entity_frame_is_serializable() {
+        let adapter = FileReplayAdapter::from_csv(SAMPLE_CSV).unwrap();
+        let frame = &adapter.frames()[0];
+        let json = serde_json::to_string(frame).unwrap();
+        let decoded: EntityFrame = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.timestamp_ms, frame.timestamp_ms);
+        assert_eq!(decoded.entities.len(), frame.entities.len());
+    }
+}

--- a/crates/edgesentry-ingest/src/entity.rs
+++ b/crates/edgesentry-ingest/src/entity.rs
@@ -1,0 +1,178 @@
+/// 2D position or velocity vector (metres or m/s).
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Vec2 {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Vec2 {
+    pub fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+
+    pub fn length(&self) -> f32 {
+        (self.x * self.x + self.y * self.y).sqrt()
+    }
+
+    pub fn normalize(&self) -> Self {
+        let len = self.length();
+        if len < f32::EPSILON {
+            Self::new(0.0, 0.0)
+        } else {
+            Self::new(self.x / len, self.y / len)
+        }
+    }
+
+    pub fn dot(&self, other: &Self) -> f32 {
+        self.x * other.x + self.y * other.y
+    }
+}
+
+impl std::ops::Sub for &Vec2 {
+    type Output = Vec2;
+    fn sub(self, other: &Vec2) -> Vec2 {
+        Vec2::new(self.x - other.x, self.y - other.y)
+    }
+}
+
+/// Physical class of an entity, used to look up braking parameters.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum EntityClass {
+    /// Counterbalanced forklift up to 3.5 T
+    Forklift,
+    /// Reach stacker / empty container handler
+    ReachStacker,
+    /// Terminal tractor / yard truck
+    TerminalTractor,
+    /// Vessel (ship) — very slow deceleration
+    Vessel,
+    /// Walking person — modelled as stopping instantly (conservative)
+    Person,
+}
+
+impl EntityClass {
+    /// Maximum service-brake deceleration in m/s².
+    /// Person returns f32::INFINITY (stops instantly — safest assumption).
+    pub fn deceleration_ms2(&self) -> f32 {
+        match self {
+            EntityClass::Forklift => 1.5,
+            EntityClass::ReachStacker => 1.0,
+            EntityClass::TerminalTractor => 2.0,
+            EntityClass::Vessel => 0.05,
+            EntityClass::Person => f32::INFINITY,
+        }
+    }
+}
+
+/// A tracked entity in the physical space.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Entity {
+    pub id: String,
+    pub class: EntityClass,
+    /// Position in metres relative to site origin.
+    pub position: Vec2,
+    /// Velocity in m/s.
+    pub velocity: Vec2,
+    /// Unix timestamp in milliseconds.
+    pub timestamp_ms: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Vec2 ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn vec2_length_unit_x() {
+        assert!((Vec2::new(1.0, 0.0).length() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn vec2_length_3_4_is_5() {
+        assert!((Vec2::new(3.0, 4.0).length() - 5.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn vec2_length_zero() {
+        assert_eq!(Vec2::new(0.0, 0.0).length(), 0.0);
+    }
+
+    #[test]
+    fn vec2_normalize_unit_x() {
+        let n = Vec2::new(5.0, 0.0).normalize();
+        assert!((n.x - 1.0).abs() < 1e-6);
+        assert!(n.y.abs() < 1e-6);
+    }
+
+    #[test]
+    fn vec2_normalize_45_degrees() {
+        let n = Vec2::new(1.0, 1.0).normalize();
+        let expected = 1.0_f32 / 2.0_f32.sqrt();
+        assert!((n.x - expected).abs() < 1e-6);
+        assert!((n.y - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn vec2_normalize_zero_vector_is_zero() {
+        let n = Vec2::new(0.0, 0.0).normalize();
+        assert_eq!(n, Vec2::new(0.0, 0.0));
+    }
+
+    #[test]
+    fn vec2_dot_orthogonal_is_zero() {
+        let a = Vec2::new(1.0, 0.0);
+        let b = Vec2::new(0.0, 1.0);
+        assert!((a.dot(&b)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn vec2_dot_parallel() {
+        let a = Vec2::new(3.0, 0.0);
+        let b = Vec2::new(4.0, 0.0);
+        assert!((a.dot(&b) - 12.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn vec2_sub() {
+        let a = Vec2::new(5.0, 3.0);
+        let b = Vec2::new(2.0, 1.0);
+        let r = &a - &b;
+        assert_eq!(r, Vec2::new(3.0, 2.0));
+    }
+
+    // ── EntityClass ───────────────────────────────────────────────────────
+
+    #[test]
+    fn entity_class_deceleration_ordering() {
+        // TerminalTractor brakes harder than Forklift, which brakes harder than Vessel
+        assert!(
+            EntityClass::TerminalTractor.deceleration_ms2()
+                > EntityClass::Forklift.deceleration_ms2()
+        );
+        assert!(
+            EntityClass::Forklift.deceleration_ms2()
+                > EntityClass::Vessel.deceleration_ms2()
+        );
+    }
+
+    #[test]
+    fn entity_class_person_is_infinity() {
+        assert_eq!(EntityClass::Person.deceleration_ms2(), f32::INFINITY);
+    }
+
+    #[test]
+    fn entity_class_all_positive() {
+        for class in &[
+            EntityClass::Forklift,
+            EntityClass::ReachStacker,
+            EntityClass::TerminalTractor,
+            EntityClass::Vessel,
+        ] {
+            assert!(
+                class.deceleration_ms2() > 0.0,
+                "{class:?} deceleration should be positive"
+            );
+        }
+    }
+}

--- a/crates/edgesentry-ingest/src/jsonl.rs
+++ b/crates/edgesentry-ingest/src/jsonl.rs
@@ -1,0 +1,133 @@
+use serde::{de::DeserializeOwned, Serialize};
+use std::io::{BufRead, BufReader, Read, Write};
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct JsonlHeader {
+    pub eds_schema: String,
+    pub version: String,
+}
+
+pub struct JsonlReader<R: Read> {
+    reader: BufReader<R>,
+    pub header: JsonlHeader,
+}
+
+impl<R: Read> JsonlReader<R> {
+    pub fn open(r: R) -> Result<Self, String> {
+        let mut reader = BufReader::new(r);
+        let mut first_line = String::new();
+        reader.read_line(&mut first_line).map_err(|e| e.to_string())?;
+        let header: JsonlHeader = serde_json::from_str(first_line.trim())
+            .map_err(|e| format!("invalid JSONL header: {e}"))?;
+        Ok(Self { reader, header })
+    }
+
+    pub fn records<T: DeserializeOwned>(&mut self) -> impl Iterator<Item = Result<T, String>> + '_ {
+        self.reader.by_ref().lines().filter_map(|line| {
+            let line = line.ok()?;
+            let line = line.trim().to_string();
+            if line.is_empty() { return None; }
+            Some(serde_json::from_str(&line).map_err(|e| e.to_string()))
+        })
+    }
+}
+
+pub struct JsonlWriter<W: Write> {
+    writer: W,
+}
+
+impl<W: Write> JsonlWriter<W> {
+    pub fn new(mut w: W, schema: &str, version: &str) -> Result<Self, String> {
+        let header = JsonlHeader {
+            eds_schema: schema.to_string(),
+            version: version.to_string(),
+        };
+        let line = serde_json::to_string(&header).map_err(|e| e.to_string())?;
+        writeln!(w, "{line}").map_err(|e| e.to_string())?;
+        Ok(Self { writer: w })
+    }
+
+    pub fn write_record<T: Serialize>(&mut self, record: &T) -> Result<(), String> {
+        let line = serde_json::to_string(record).map_err(|e| e.to_string())?;
+        writeln!(self.writer, "{line}").map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct TestRecord {
+        id: u32,
+        value: String,
+    }
+
+    #[test]
+    fn roundtrip_single_record() {
+        let mut buf = Vec::new();
+        {
+            let mut writer = JsonlWriter::new(&mut buf, "test.schema", "1.0").unwrap();
+            writer.write_record(&TestRecord { id: 1, value: "hello".to_string() }).unwrap();
+        }
+        let cursor = Cursor::new(buf);
+        let mut reader = JsonlReader::open(cursor).unwrap();
+        assert_eq!(reader.header.eds_schema, "test.schema");
+        assert_eq!(reader.header.version, "1.0");
+        let records: Vec<TestRecord> = reader.records().map(|r| r.unwrap()).collect();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0], TestRecord { id: 1, value: "hello".to_string() });
+    }
+
+    #[test]
+    fn roundtrip_multiple_records() {
+        let mut buf = Vec::new();
+        {
+            let mut writer = JsonlWriter::new(&mut buf, "multi.schema", "2.0").unwrap();
+            for i in 0..5u32 {
+                writer.write_record(&TestRecord { id: i, value: format!("item-{i}") }).unwrap();
+            }
+        }
+        let cursor = Cursor::new(buf);
+        let mut reader = JsonlReader::open(cursor).unwrap();
+        let records: Vec<TestRecord> = reader.records().map(|r| r.unwrap()).collect();
+        assert_eq!(records.len(), 5);
+        assert_eq!(records[3].id, 3);
+        assert_eq!(records[3].value, "item-3");
+    }
+
+    #[test]
+    fn header_schema_and_version_preserved() {
+        let mut buf = Vec::new();
+        JsonlWriter::new(&mut buf, "eds.entity-frame", "0.1").unwrap();
+        let cursor = Cursor::new(buf);
+        let reader = JsonlReader::open(cursor).unwrap();
+        assert_eq!(reader.header.eds_schema, "eds.entity-frame");
+        assert_eq!(reader.header.version, "0.1");
+    }
+
+    #[test]
+    fn invalid_header_returns_error() {
+        let data = b"not a json header\n{\"id\":1}\n";
+        let cursor = Cursor::new(data.as_slice());
+        assert!(JsonlReader::open(cursor).is_err());
+    }
+
+    #[test]
+    fn empty_lines_are_skipped() {
+        let mut buf = Vec::new();
+        {
+            let mut writer = JsonlWriter::new(&mut buf, "s", "1").unwrap();
+            writer.write_record(&TestRecord { id: 1, value: "a".into() }).unwrap();
+        }
+        // Inject empty lines into the buffer after the header
+        let mut text = String::from_utf8(buf).unwrap();
+        text.push('\n');
+        text.push('\n');
+        let cursor = Cursor::new(text.into_bytes());
+        let mut reader = JsonlReader::open(cursor).unwrap();
+        let records: Vec<TestRecord> = reader.records().map(|r| r.unwrap()).collect();
+        assert_eq!(records.len(), 1);
+    }
+}

--- a/crates/edgesentry-ingest/src/lib.rs
+++ b/crates/edgesentry-ingest/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod entity;
+pub mod jsonl;
+pub mod csv_replay;

--- a/crates/edgesentry-inspect/Cargo.toml
+++ b/crates/edgesentry-inspect/Cargo.toml
@@ -28,9 +28,9 @@ glam = "0.32.1"
 image = { version = "0.25", default-features = false, features = ["png"] }
 toml = "0.8"
 ureq = "2"
+tempfile = "3"
 tract-onnx = "0.22"
 
 [dev-dependencies]
-tempfile = "3"
 mockito  = "1"
 tokio    = { version = "1", features = ["rt", "macros"] }

--- a/crates/edgesentry-inspect/config.example.toml
+++ b/crates/edgesentry-inspect/config.example.toml
@@ -3,8 +3,17 @@
 # Copy to config.toml and adjust paths before running:
 #   edgesentry-inspect scan --config config.toml
 
-# Path to the IFC design file (reference model).
+# IFC design file — choose one of the two options below.
+#
+# Option A — local file (default)
 ifc_path = "design.ifc"
+#
+# Option B — remote URL fetched before the pipeline runs (mutually exclusive with ifc_path).
+# The file is downloaded to a secure temp path; `ifc_path` is ignored when [ifc] is set.
+# Omit `token` for self-authenticating pre-signed S3 URLs.
+# [ifc]
+# url   = "https://bim.example.com/elements/E-001/ifc"
+# token = "eyJ..."   # optional Bearer token
 
 # Path to the as-built scan in ASCII PLY format.
 scan_path = "scan.ply"

--- a/crates/edgesentry-inspect/src/config.rs
+++ b/crates/edgesentry-inspect/src/config.rs
@@ -10,7 +10,17 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ScanConfig {
     /// Path to the IFC design file (reference model).
+    ///
+    /// Mutually exclusive with the `[ifc]` remote-URL section.
+    /// Defaults to an empty path when `[ifc]` is provided instead.
+    #[serde(default)]
     pub ifc_path: PathBuf,
+    /// Remote IFC source fetched via HTTPS before the pipeline runs.
+    ///
+    /// When set, `ifc_path` is ignored.  The IFC is downloaded to a secure
+    /// temp file and passed to the loader unchanged.
+    #[serde(default)]
+    pub ifc: Option<IfcUrlConfig>,
     /// Path to the scan point cloud (PLY, ASCII format).
     pub scan_path: PathBuf,
     /// Optional path to a pre-extracted `reference.json` mesh file.
@@ -92,6 +102,28 @@ pub struct OutputConfig {
 
 fn default_threshold() -> f64 {
     10.0
+}
+
+/// Remote IFC source — fetched from an HTTPS URL before the pipeline runs.
+///
+/// Supports optional Bearer-token authentication for BIM servers and
+/// self-authenticating pre-signed S3 URLs alike.
+///
+/// # Example (`config.toml`)
+///
+/// ```toml
+/// [ifc]
+/// url   = "https://bim.example.com/elements/E-001/ifc"
+/// token = "eyJ..."   # optional; omit for pre-signed URLs
+/// ```
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct IfcUrlConfig {
+    /// HTTPS URL of the IFC file (direct download or pre-signed S3 URL).
+    pub url: String,
+    /// Bearer token sent as `Authorization: Bearer <token>`.
+    /// Leave unset when using a self-authenticating pre-signed URL.
+    #[serde(default)]
+    pub token: Option<String>,
 }
 
 /// Parse a [`ScanConfig`] from a TOML file.

--- a/crates/edgesentry-inspect/src/ifc.rs
+++ b/crates/edgesentry-inspect/src/ifc.rs
@@ -3,7 +3,10 @@
 //! Parses `IFCCARTESIANPOINT` entries from an IFC file and returns them as a
 //! `Vec<Point3D>`. Only 3D points (three coordinate values) are included;
 //! 2D points are silently skipped.
+//!
+//! Remote IFC files can be fetched with [`fetch_ifc_url`] before loading.
 
+use std::io::Write as _;
 use std::path::Path;
 
 use trilink_core::Point3D;
@@ -16,6 +19,42 @@ pub enum IfcError {
 
     #[error("no 3D IFCCARTESIANPOINT entries found in file")]
     NoPoints,
+
+    #[error("HTTP fetch failed: {0}")]
+    Fetch(String),
+}
+
+/// Fetch an IFC file from `url` into a secure temp file and return it.
+///
+/// The [`tempfile::NamedTempFile`] is automatically deleted when dropped, so
+/// callers must keep it alive for as long as the path is needed.
+///
+/// # Authentication
+///
+/// Pass `token` to send `Authorization: Bearer <token>`.  Leave `None` for
+/// unauthenticated or self-authenticating pre-signed S3 URLs.
+pub fn fetch_ifc_url(url: &str, token: Option<&str>) -> Result<tempfile::NamedTempFile, IfcError> {
+    let resp = {
+        let req = ureq::get(url);
+        if let Some(t) = token {
+            req.set("Authorization", &format!("Bearer {t}"))
+        } else {
+            req
+        }
+        .call()
+        .map_err(|e| IfcError::Fetch(e.to_string()))?
+    };
+
+    let mut tmp = tempfile::Builder::new()
+        .prefix("edgesentry-ifc-")
+        .suffix(".ifc")
+        .tempfile()
+        .map_err(IfcError::Io)?;
+
+    std::io::copy(&mut resp.into_reader(), tmp.as_file_mut()).map_err(IfcError::Io)?;
+    tmp.flush().map_err(IfcError::Io)?;
+
+    Ok(tmp)
 }
 
 /// Load all 3-dimensional `IFCCARTESIANPOINT` entries from an IFC STEP-21 file.
@@ -100,5 +139,47 @@ END-ISO-10303-21;
     fn empty_file_returns_empty() {
         let pts = parse_ifc_points("ISO-10303-21;\nHEADER;\nENDSEC;\n");
         assert!(pts.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // fetch_ifc_url tests (require mockito)
+    // ------------------------------------------------------------------
+
+    const MINIMAL_IFC: &str = "#1= IFCCARTESIANPOINT((1.0,2.0,3.0));";
+
+    #[test]
+    fn fetch_ifc_url_downloads_content() {
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/wall.ifc")
+            .with_status(200)
+            .with_body(MINIMAL_IFC)
+            .create();
+
+        let tmp = fetch_ifc_url(&format!("{}/wall.ifc", server.url()), None).unwrap();
+        let content = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(content.trim(), MINIMAL_IFC);
+    }
+
+    #[test]
+    fn fetch_ifc_url_sends_bearer_token() {
+        let mut server = mockito::Server::new();
+        let _m = server
+            .mock("GET", "/wall.ifc")
+            .match_header("authorization", "Bearer test-token-abc")
+            .with_status(200)
+            .with_body(MINIMAL_IFC)
+            .create();
+
+        fetch_ifc_url(&format!("{}/wall.ifc", server.url()), Some("test-token-abc")).unwrap();
+    }
+
+    #[test]
+    fn fetch_ifc_url_404_returns_error() {
+        let mut server = mockito::Server::new();
+        let _m = server.mock("GET", "/missing.ifc").with_status(404).create();
+
+        let result = fetch_ifc_url(&format!("{}/missing.ifc", server.url()), None);
+        assert!(matches!(result, Err(IfcError::Fetch(_))));
     }
 }

--- a/crates/edgesentry-inspect/src/lib.rs
+++ b/crates/edgesentry-inspect/src/lib.rs
@@ -27,7 +27,7 @@ pub mod report;
 // Top-level re-exports — stable public API surface
 // ---------------------------------------------------------------------------
 
-pub use config::{CameraConfig, InferenceConfig, InferenceMode, OutputConfig, ScanConfig};
+pub use config::{CameraConfig, IfcUrlConfig, InferenceConfig, InferenceMode, OutputConfig, ScanConfig};
 pub use deviation::DeviationReport;
 pub use ingress::{FrameSource, SensorFrame};
 pub use pipeline::{run_scan, ScanError, ScanOutput};

--- a/crates/edgesentry-inspect/src/pipeline.rs
+++ b/crates/edgesentry-inspect/src/pipeline.rs
@@ -15,7 +15,7 @@ use crate::{
     config::{InferenceMode, ScanConfig},
     deviation::{compute_deviation, per_point_deviations_mm, DeviationReport},
     heatmap::{render_heatmap, write_heatmap_png},
-    ifc::load_ifc_points,
+    ifc::{fetch_ifc_url, load_ifc_points},
     inference::{depth_map_to_png, http_infer, mock_infer, onnx_infer, InferenceError},
     ply::{load_ply_points, PlyError},
     points::{write_points, PointsError, PointsJson},
@@ -77,8 +77,20 @@ pub enum ScanError {
 /// 9. Write `report.json`, `heatmap.png`, `points.json` (and optionally `reference.json`)
 pub fn run_scan(config: &ScanConfig) -> Result<ScanOutput, ScanError> {
     // Step 1 — IFC reference cloud
+    // Resolve the IFC source: remote URL (fetched to a temp file) or local path.
+    // `_ifc_tmp` must be kept alive here so the temp file is not deleted before loading.
+    let mut _ifc_tmp: Option<tempfile::NamedTempFile> = None;
+    let ifc_local_path: std::path::PathBuf = if let Some(url_cfg) = &config.ifc {
+        let tmp = fetch_ifc_url(&url_cfg.url, url_cfg.token.as_deref())
+            .map_err(|e| ScanError::Ifc(e.to_string()))?;
+        let path = tmp.path().to_owned();
+        _ifc_tmp = Some(tmp);
+        path
+    } else {
+        config.ifc_path.clone()
+    };
     let reference =
-        load_ifc_points(&config.ifc_path).map_err(|e| ScanError::Ifc(e.to_string()))?;
+        load_ifc_points(&ifc_local_path).map_err(|e| ScanError::Ifc(e.to_string()))?;
 
     // Step 2 — Scan point cloud
     let scan = load_ply_points(&config.scan_path)?;

--- a/crates/edgesentry-inspect/tests/fixtures_integration.rs
+++ b/crates/edgesentry-inspect/tests/fixtures_integration.rs
@@ -100,7 +100,7 @@ fn pipeline_detects_defect_in_generated_fixtures() {
 
     let out_dir = tmp.path().join("out");
     let cfg = ScanConfig {
-        ifc_path: tmp.path().join("wall_slab.ifc"),
+        ifc: None, ifc_path: tmp.path().join("wall_slab.ifc"),
         scan_path: tmp.path().join("wall_slab_scan.ply"),
         camera: CameraConfig {
             fx: 1280.0,

--- a/crates/edgesentry-inspect/tests/scan_pipeline_integration.rs
+++ b/crates/edgesentry-inspect/tests/scan_pipeline_integration.rs
@@ -53,7 +53,7 @@ fn scan_off_mode_produces_report_and_heatmap() {
     write_ply_points(&ply_path, &scan_pts).unwrap();
 
     let cfg = ScanConfig {
-        ifc_path: sample_ifc(),
+        ifc: None, ifc_path: sample_ifc(),
         scan_path: ply_path,
         camera: default_camera(),
         inference: InferenceConfig {
@@ -101,7 +101,7 @@ fn scan_zero_deviation_fully_compliant() {
     write_ply_points(&ply_path, &reference).unwrap();
 
     let cfg = ScanConfig {
-        ifc_path: sample_ifc(),
+        ifc: None, ifc_path: sample_ifc(),
         scan_path: ply_path,
         camera: default_camera(),
         inference: InferenceConfig {
@@ -131,7 +131,7 @@ fn scan_mock_mode_returns_one_detection_without_server() {
     write_ply_points(&ply_path, &scan_pts).unwrap();
 
     let cfg = ScanConfig {
-        ifc_path: sample_ifc(),
+        ifc: None, ifc_path: sample_ifc(),
         scan_path: ply_path,
         camera: default_camera(),
         inference: InferenceConfig {
@@ -169,7 +169,7 @@ fn scan_onnx_mode_detects_fixture_defect() {
     edgesentry_inspect::fixtures::generate_fixtures(fixture_dir.path()).unwrap();
 
     let cfg = edgesentry_inspect::config::ScanConfig {
-        ifc_path:  fixture_dir.path().join("wall_slab.ifc"),
+        ifc: None, ifc_path:  fixture_dir.path().join("wall_slab.ifc"),
         scan_path: fixture_dir.path().join("wall_slab_scan.ply"),
         camera: edgesentry_inspect::config::CameraConfig {
             fx: 1280.0, fy: 1080.0,
@@ -229,7 +229,7 @@ fn scan_http_mode_returns_detections() {
     let endpoint = format!("{}/detect", server.url());
 
     let cfg = ScanConfig {
-        ifc_path: sample_ifc(),
+        ifc: None, ifc_path: sample_ifc(),
         scan_path: ply_path,
         camera: default_camera(),
         inference: InferenceConfig {

--- a/crates/edgesentry-profile/Cargo.toml
+++ b/crates/edgesentry-profile/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "edgesentry-profile"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Profile loader and validator — rules.json format checking and KB coverage"
+
+[dependencies]
+edgesentry-evaluate = { path = "../edgesentry-evaluate" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/edgesentry-profile/src/lib.rs
+++ b/crates/edgesentry-profile/src/lib.rs
@@ -1,0 +1,512 @@
+use std::collections::HashSet;
+use std::path::Path;
+use std::fs;
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// The result of validating a profile directory.
+#[derive(Debug, Default)]
+pub struct ValidationReport {
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+impl ValidationReport {
+    pub fn is_valid(&self) -> bool {
+        self.errors.is_empty()
+    }
+}
+
+/// Validate a profile directory and return a `ValidationReport`.
+///
+/// Checks:
+/// - rules.json exists and is valid JSON
+/// - Top-level is a non-empty array
+/// - Each rule has rule_id (SCREAMING_SNAKE_CASE, unique, no spaces)
+/// - Valid condition syntax
+/// - Valid severity values
+/// - Non-empty regulation
+/// - zone polygons have ≥3 vertices
+/// - KB file coverage (missing/orphaned KB files)
+pub fn validate_profile(profile_dir: &Path) -> ValidationReport {
+    let mut report = ValidationReport::default();
+    let rule_ids = validate_rules_json(profile_dir, &mut report);
+    validate_kb(profile_dir, &rule_ids, &mut report);
+    report
+}
+
+/// Load and parse rules from a profile directory's `rules.json`.
+///
+/// Returns the parsed `Rule` list, or an error string.
+pub fn load_profile(profile_dir: &Path) -> Result<Vec<edgesentry_evaluate::Rule>, String> {
+    let rules_path = profile_dir.join("rules.json");
+    let content = fs::read_to_string(&rules_path)
+        .map_err(|e| format!("cannot read {}: {e}", rules_path.display()))?;
+    edgesentry_evaluate::load_rules(&content)
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/// Returns rule_ids found in rules.json (empty on parse failure).
+fn validate_rules_json(profile_dir: &Path, report: &mut ValidationReport) -> Vec<String> {
+    let rules_path = profile_dir.join("rules.json");
+
+    // 1. File exists
+    if !rules_path.exists() {
+        report.errors.push(format!("rules.json not found at {}", rules_path.display()));
+        return vec![];
+    }
+
+    // 2. Valid JSON
+    let content = match fs::read_to_string(&rules_path) {
+        Ok(c) => c,
+        Err(e) => {
+            report.errors.push(format!("cannot read rules.json: {e}"));
+            return vec![];
+        }
+    };
+    let json: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            report.errors.push(format!("rules.json is not valid JSON: {e}"));
+            return vec![];
+        }
+    };
+
+    // 3. Top-level is an array
+    let rules = match json.as_array() {
+        Some(r) => r,
+        None => {
+            report.errors.push("rules.json must be a JSON array at the top level".to_string());
+            return vec![];
+        }
+    };
+
+    if rules.is_empty() {
+        report.errors.push("rules.json contains no rules".to_string());
+        return vec![];
+    }
+
+    // 4. Validate each rule
+    let mut rule_ids: Vec<String> = Vec::new();
+    let mut seen_ids: HashSet<String> = HashSet::new();
+
+    for (i, rule) in rules.iter().enumerate() {
+        let idx = i + 1;
+        validate_rule(rule, idx, &mut rule_ids, &mut seen_ids, report);
+    }
+
+    rule_ids
+}
+
+fn validate_rule(
+    rule: &serde_json::Value,
+    idx: usize,
+    rule_ids: &mut Vec<String>,
+    seen_ids: &mut HashSet<String>,
+    report: &mut ValidationReport,
+) {
+    let obj = match rule.as_object() {
+        Some(o) => o,
+        None => {
+            report.errors.push(format!("Rule {idx}: must be a JSON object"));
+            return;
+        }
+    };
+
+    // rule_id
+    let rule_id = match obj.get("rule_id").and_then(|v| v.as_str()) {
+        Some(id) => id.to_string(),
+        None => {
+            report.errors.push(format!("Rule {idx}: missing required field \"rule_id\" (string)"));
+            return;
+        }
+    };
+
+    if rule_id.is_empty() {
+        report.errors.push(format!("Rule {idx}: \"rule_id\" must not be empty"));
+        return;
+    }
+    if rule_id.contains(' ') {
+        report.errors.push(format!(
+            "Rule {idx} ({rule_id}): \"rule_id\" must not contain spaces"
+        ));
+    }
+    if rule_id != rule_id.to_uppercase() {
+        report.warnings.push(format!(
+            "Rule {idx} ({rule_id}): \"rule_id\" should be SCREAMING_SNAKE_CASE"
+        ));
+    }
+    if seen_ids.contains(&rule_id) {
+        report.errors.push(format!("Rule {idx}: duplicate rule_id \"{rule_id}\""));
+    } else {
+        seen_ids.insert(rule_id.clone());
+        rule_ids.push(rule_id.clone());
+    }
+
+    // condition
+    match obj.get("condition").and_then(|v| v.as_str()) {
+        None => {
+            report.errors.push(format!(
+                "Rule {idx} ({rule_id}): missing required field \"condition\" (string)"
+            ));
+        }
+        Some(cond) => validate_condition(cond, obj, &rule_id, idx, report),
+    }
+
+    // severity
+    match obj.get("severity").and_then(|v| v.as_str()) {
+        None => {
+            report.errors.push(format!(
+                "Rule {idx} ({rule_id}): missing required field \"severity\""
+            ));
+        }
+        Some(sev) => match sev {
+            "LOW" | "MEDIUM" | "HIGH" | "CRITICAL" => {}
+            _ => {
+                report.errors.push(format!(
+                    "Rule {idx} ({rule_id}): invalid severity \"{sev}\""
+                ));
+            }
+        },
+    }
+
+    // regulation
+    match obj.get("regulation").and_then(|v| v.as_str()) {
+        None => {
+            report.errors.push(format!(
+                "Rule {idx} ({rule_id}): missing required field \"regulation\" (string)"
+            ));
+        }
+        Some(reg) if reg.trim().is_empty() => {
+            report.errors.push(format!(
+                "Rule {idx} ({rule_id}): \"regulation\" must not be empty"
+            ));
+        }
+        Some(_) => {}
+    }
+}
+
+fn validate_condition(
+    cond: &str,
+    obj: &serde_json::Map<String, serde_json::Value>,
+    rule_id: &str,
+    idx: usize,
+    report: &mut ValidationReport,
+) {
+    let cond = cond.trim();
+
+    if let Some(rest) = cond.strip_prefix("distance < ") {
+        match rest.trim().parse::<f64>() {
+            Ok(n) if n > 0.0 => {}
+            Ok(_) => report.errors.push(format!(
+                "Rule {idx} ({rule_id}): distance threshold must be > 0"
+            )),
+            Err(_) => report.errors.push(format!(
+                "Rule {idx} ({rule_id}): invalid number in condition \"{cond}\""
+            )),
+        }
+    } else if let Some(rest) = cond.strip_prefix("ttc < ") {
+        match rest.trim().parse::<f64>() {
+            Ok(n) if n > 0.0 => {}
+            Ok(_) => report.errors.push(format!(
+                "Rule {idx} ({rule_id}): ttc threshold must be > 0"
+            )),
+            Err(_) => report.errors.push(format!(
+                "Rule {idx} ({rule_id}): invalid number in condition \"{cond}\""
+            )),
+        }
+    } else if cond == "zone_member" {
+        match obj.get("zone") {
+            None => {
+                report.errors.push(format!(
+                    "Rule {idx} ({rule_id}): condition \"zone_member\" requires a \"zone\" field"
+                ));
+            }
+            Some(zone) => validate_zone(zone, rule_id, idx, report),
+        }
+    } else {
+        report.errors.push(format!(
+            "Rule {idx} ({rule_id}): unknown condition \"{cond}\""
+        ));
+    }
+}
+
+fn validate_zone(
+    zone: &serde_json::Value,
+    rule_id: &str,
+    idx: usize,
+    report: &mut ValidationReport,
+) {
+    let arr = match zone.as_array() {
+        Some(a) => a,
+        None => {
+            report.errors.push(format!(
+                "Rule {idx} ({rule_id}): \"zone\" must be an array of [x, y] pairs"
+            ));
+            return;
+        }
+    };
+
+    if arr.len() < 3 {
+        report.errors.push(format!(
+            "Rule {idx} ({rule_id}): \"zone\" polygon must have at least 3 vertices, got {}",
+            arr.len()
+        ));
+        return;
+    }
+
+    for (vi, vertex) in arr.iter().enumerate() {
+        let pair = match vertex.as_array() {
+            Some(p) if p.len() == 2 => p,
+            _ => {
+                report.errors.push(format!(
+                    "Rule {idx} ({rule_id}): zone vertex {vi} must be [x, y]"
+                ));
+                return;
+            }
+        };
+        for coord in pair {
+            if !coord.is_number() {
+                report.errors.push(format!(
+                    "Rule {idx} ({rule_id}): zone vertex {vi} coordinates must be numbers"
+                ));
+                return;
+            }
+        }
+    }
+}
+
+fn validate_kb(profile_dir: &Path, rule_ids: &[String], report: &mut ValidationReport) {
+    let kb_dir = profile_dir.join("kb");
+
+    if !kb_dir.exists() {
+        report.warnings.push(
+            "kb/ directory not found — LLM explanations will fall back to \"No KB entry\""
+                .to_string(),
+        );
+        return;
+    }
+
+    // Collect existing KB files
+    let kb_files: HashSet<String> = match fs::read_dir(&kb_dir) {
+        Ok(entries) => entries
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().and_then(|s| s.to_str()) == Some("txt"))
+            .filter_map(|e| e.path().file_stem()?.to_str().map(str::to_string))
+            .collect(),
+        Err(e) => {
+            report.errors.push(format!("cannot read kb/: {e}"));
+            return;
+        }
+    };
+
+    // Each rule should have a KB file
+    for rule_id in rule_ids {
+        if kb_files.contains(rule_id) {
+            let path = kb_dir.join(format!("{rule_id}.txt"));
+            let content = fs::read_to_string(&path).unwrap_or_default();
+            if content.trim().is_empty() {
+                report.warnings.push(format!("kb/{rule_id}.txt exists but is empty"));
+            }
+        } else {
+            report.warnings.push(format!(
+                "kb/{rule_id}.txt not found — LLM explanation for {rule_id} will be ungrounded"
+            ));
+        }
+    }
+
+    // Warn about orphaned KB files (no matching rule)
+    let rule_set: HashSet<&str> = rule_ids.iter().map(String::as_str).collect();
+    for kb_id in &kb_files {
+        if !rule_set.contains(kb_id.as_str()) {
+            report.warnings.push(format!(
+                "kb/{kb_id}.txt has no matching rule in rules.json (orphaned)"
+            ));
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_profile(dir: &Path, rules: &str, kb: &[(&str, &str)]) {
+        fs::write(dir.join("rules.json"), rules).unwrap();
+        let kb_dir = dir.join("kb");
+        fs::create_dir_all(&kb_dir).unwrap();
+        for (name, content) in kb {
+            fs::write(kb_dir.join(format!("{name}.txt")), content).unwrap();
+        }
+    }
+
+    fn run(dir: &Path) -> ValidationReport {
+        validate_profile(dir)
+    }
+
+    #[test]
+    fn valid_profile_passes() {
+        let tmp = TempDir::new().unwrap();
+        write_profile(tmp.path(), r#"[
+            {"rule_id":"MIN_CLEARANCE","condition":"distance < 5.0",
+             "severity":"HIGH","regulation":"Safety Code §3.1"}
+        ]"#, &[("MIN_CLEARANCE", "Keep 5 m clearance.")]);
+        let r = run(tmp.path());
+        assert_eq!(r.errors.len(), 0);
+        assert_eq!(r.warnings.len(), 0);
+    }
+
+    #[test]
+    fn missing_rules_json_is_error() {
+        let tmp = TempDir::new().unwrap();
+        let r = run(tmp.path());
+        assert!(!r.errors.is_empty());
+    }
+
+    #[test]
+    fn invalid_json_is_error() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("rules.json"), "not json").unwrap();
+        let r = run(tmp.path());
+        assert!(!r.errors.is_empty());
+    }
+
+    #[test]
+    fn empty_array_is_error() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("rules.json"), "[]").unwrap();
+        let r = run(tmp.path());
+        assert!(!r.errors.is_empty());
+    }
+
+    #[test]
+    fn duplicate_rule_ids_are_error() {
+        let tmp = TempDir::new().unwrap();
+        write_profile(tmp.path(), r#"[
+            {"rule_id":"R1","condition":"distance < 5.0","severity":"HIGH","regulation":"X §1"},
+            {"rule_id":"R1","condition":"ttc < 3.0","severity":"LOW","regulation":"X §2"}
+        ]"#, &[]);
+        let r = run(tmp.path());
+        assert!(!r.errors.is_empty());
+    }
+
+    #[test]
+    fn invalid_severity_is_error() {
+        let tmp = TempDir::new().unwrap();
+        write_profile(tmp.path(), r#"[
+            {"rule_id":"R1","condition":"distance < 5.0","severity":"URGENT","regulation":"X §1"}
+        ]"#, &[]);
+        let r = run(tmp.path());
+        assert!(!r.errors.is_empty());
+    }
+
+    #[test]
+    fn unknown_condition_is_error() {
+        let tmp = TempDir::new().unwrap();
+        write_profile(tmp.path(), r#"[
+            {"rule_id":"R1","condition":"speed > 10","severity":"HIGH","regulation":"X §1"}
+        ]"#, &[]);
+        let r = run(tmp.path());
+        assert!(!r.errors.is_empty());
+    }
+
+    #[test]
+    fn zone_member_without_zone_is_error() {
+        let tmp = TempDir::new().unwrap();
+        write_profile(tmp.path(), r#"[
+            {"rule_id":"ZONE","condition":"zone_member","severity":"CRITICAL","regulation":"X §2"}
+        ]"#, &[]);
+        let r = run(tmp.path());
+        assert!(!r.errors.is_empty());
+    }
+
+    #[test]
+    fn zone_member_with_valid_polygon_passes() {
+        let tmp = TempDir::new().unwrap();
+        write_profile(tmp.path(), r#"[
+            {"rule_id":"ZONE","condition":"zone_member","severity":"CRITICAL",
+             "regulation":"X §2","zone":[[0,0],[10,0],[10,10],[0,10]]}
+        ]"#, &[("ZONE", "Exclusion zone.")]);
+        let r = run(tmp.path());
+        assert_eq!(r.errors.len(), 0);
+    }
+
+    #[test]
+    fn zone_with_fewer_than_3_vertices_is_error() {
+        let tmp = TempDir::new().unwrap();
+        write_profile(tmp.path(), r#"[
+            {"rule_id":"ZONE","condition":"zone_member","severity":"CRITICAL",
+             "regulation":"X §2","zone":[[0,0],[10,0]]}
+        ]"#, &[]);
+        let r = run(tmp.path());
+        assert!(!r.errors.is_empty());
+    }
+
+    #[test]
+    fn missing_kb_file_is_warning_not_error() {
+        let tmp = TempDir::new().unwrap();
+        write_profile(tmp.path(), r#"[
+            {"rule_id":"R1","condition":"distance < 5.0","severity":"HIGH","regulation":"X §1"}
+        ]"#, &[]); // no KB files
+        let r = run(tmp.path());
+        assert_eq!(r.errors.len(), 0);
+        assert!(!r.warnings.is_empty());
+    }
+
+    #[test]
+    fn orphaned_kb_file_is_warning() {
+        let tmp = TempDir::new().unwrap();
+        write_profile(tmp.path(), r#"[
+            {"rule_id":"R1","condition":"distance < 5.0","severity":"HIGH","regulation":"X §1"}
+        ]"#, &[
+            ("R1", "Relevant regulation text."),
+            ("R2_ORPHAN", "This has no matching rule."),
+        ]);
+        let r = run(tmp.path());
+        assert_eq!(r.errors.len(), 0);
+        assert!(!r.warnings.is_empty());
+    }
+
+    #[test]
+    fn missing_regulation_field_is_error() {
+        let tmp = TempDir::new().unwrap();
+        write_profile(tmp.path(), r#"[
+            {"rule_id":"R1","condition":"distance < 5.0","severity":"HIGH"}
+        ]"#, &[]);
+        let r = run(tmp.path());
+        assert!(!r.errors.is_empty());
+    }
+
+    #[test]
+    fn rule_id_with_spaces_is_error() {
+        let tmp = TempDir::new().unwrap();
+        write_profile(tmp.path(), r#"[
+            {"rule_id":"bad id","condition":"distance < 5.0","severity":"HIGH","regulation":"X §1"}
+        ]"#, &[]);
+        let r = run(tmp.path());
+        assert!(!r.errors.is_empty());
+    }
+
+    #[test]
+    fn load_profile_returns_rules() {
+        let tmp = TempDir::new().unwrap();
+        write_profile(tmp.path(), r#"[
+            {"rule_id":"R1","condition":"distance < 5.0","severity":"HIGH","regulation":"X §1"},
+            {"rule_id":"R2","condition":"ttc < 3.0","severity":"LOW","regulation":"X §2"}
+        ]"#, &[]);
+        let rules = load_profile(tmp.path()).unwrap();
+        assert_eq!(rules.len(), 2);
+        assert_eq!(rules[0].rule_id, "R1");
+        assert_eq!(rules[1].rule_id, "R2");
+    }
+
+    #[test]
+    fn load_profile_missing_file_is_error() {
+        let tmp = TempDir::new().unwrap();
+        assert!(load_profile(tmp.path()).is_err());
+    }
+}

--- a/crates/eds/Cargo.toml
+++ b/crates/eds/Cargo.toml
@@ -23,11 +23,16 @@ s3       = ["edgesentry-audit/s3",       "dep:tokio"]
 postgres = ["edgesentry-audit/postgres"]
 
 [dependencies]
-edgesentry-audit   = { path = "../edgesentry-audit" }
-edgesentry-inspect = { path = "../edgesentry-inspect" }
+edgesentry-audit    = { path = "../edgesentry-audit" }
+edgesentry-inspect  = { path = "../edgesentry-inspect" }
+edgesentry-ingest   = { path = "../edgesentry-ingest" }
+edgesentry-compute  = { path = "../edgesentry-compute" }
+edgesentry-evaluate = { path = "../edgesentry-evaluate" }
+edgesentry-profile  = { path = "../edgesentry-profile" }
 clap          = { workspace = true }
 ed25519-dalek = { workspace = true }
 hex           = { workspace = true }
+serde         = { workspace = true }
 serde_json    = { workspace = true }
 ureq          = "2"
 tokio = { version = "1", features = ["rt-multi-thread"], optional = true }

--- a/crates/eds/src/compute.rs
+++ b/crates/eds/src/compute.rs
@@ -1,0 +1,117 @@
+//! `eds compute` subcommands — physics measurements over entity frames.
+
+use clap::Subcommand;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+use edgesentry_compute::{braking_distance, euclidean_distance, relative_velocity, time_to_collision};
+use edgesentry_ingest::csv_replay::EntityFrame;
+use edgesentry_ingest::jsonl::{JsonlReader, JsonlWriter};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Measurement {
+    pub timestamp_ms: u64,
+    pub entity_a: String,
+    pub entity_b: Option<String>,
+    pub kind: MeasurementKind,
+    pub value: f32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum MeasurementKind {
+    Distance,
+    Ttc,
+    BrakingDistance,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum ComputeCommand {
+    /// Compute measurements (distances, TTC, braking distances) from EntityFrame JSONL.
+    Run {
+        /// Input EntityFrame JSONL file.
+        #[arg(long)]
+        input: PathBuf,
+
+        /// Output Measurement JSONL file.
+        #[arg(long)]
+        out: PathBuf,
+    },
+}
+
+pub fn run(cmd: ComputeCommand) -> Result<(), Box<dyn std::error::Error>> {
+    match cmd {
+        ComputeCommand::Run { input, out } => run_compute(input, out),
+    }
+}
+
+fn run_compute(input: PathBuf, out: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let file = fs::File::open(&input)?;
+    let mut reader = JsonlReader::open(file)
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    let frames: Vec<EntityFrame> = reader
+        .records()
+        .collect::<Result<Vec<_>, String>>()
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    let out_file = fs::File::create(&out)?;
+    let mut writer = JsonlWriter::new(out_file, "eds.measurement", "0.1")
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    let mut total = 0usize;
+    for frame in &frames {
+        let ts = frame.timestamp_ms;
+        let entities = &frame.entities;
+
+        // Pairwise: distance and TTC
+        for i in 0..entities.len() {
+            for j in (i + 1)..entities.len() {
+                let a = &entities[i];
+                let b = &entities[j];
+
+                let dist = euclidean_distance(a, b);
+                writer.write_record(&Measurement {
+                    timestamp_ms: ts,
+                    entity_a: a.id.clone(),
+                    entity_b: Some(b.id.clone()),
+                    kind: MeasurementKind::Distance,
+                    value: dist,
+                }).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+                total += 1;
+
+                let rv = relative_velocity(a, b);
+                let ttc = time_to_collision(dist, rv);
+                writer.write_record(&Measurement {
+                    timestamp_ms: ts,
+                    entity_a: a.id.clone(),
+                    entity_b: Some(b.id.clone()),
+                    kind: MeasurementKind::Ttc,
+                    value: ttc,
+                }).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+                total += 1;
+            }
+        }
+
+        // Per-entity: braking distance
+        for entity in entities {
+            let speed = entity.velocity.x.hypot(entity.velocity.y);
+            let bd = braking_distance(speed, &entity.class);
+            writer.write_record(&Measurement {
+                timestamp_ms: ts,
+                entity_a: entity.id.clone(),
+                entity_b: None,
+                kind: MeasurementKind::BrakingDistance,
+                value: bd,
+            }).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+            total += 1;
+        }
+    }
+
+    eprintln!(
+        "compute run: wrote {total} measurement(s) from {} frame(s) to {}",
+        frames.len(),
+        out.display()
+    );
+    Ok(())
+}

--- a/crates/eds/src/evaluate.rs
+++ b/crates/eds/src/evaluate.rs
@@ -1,0 +1,71 @@
+//! `eds evaluate` subcommands — rule evaluation over entity frames.
+
+use clap::Subcommand;
+use std::fs;
+use std::path::PathBuf;
+
+use edgesentry_evaluate::{evaluate, RiskEvent};
+use edgesentry_ingest::csv_replay::EntityFrame;
+use edgesentry_ingest::jsonl::{JsonlReader, JsonlWriter};
+use edgesentry_profile::load_profile;
+
+#[derive(Debug, Subcommand)]
+pub enum EvaluateCommand {
+    /// Evaluate rules against EntityFrame JSONL and write RiskEvent JSONL.
+    Run {
+        /// Input EntityFrame JSONL file.
+        #[arg(long)]
+        input: PathBuf,
+
+        /// Profile directory containing rules.json.
+        #[arg(long)]
+        profile: PathBuf,
+
+        /// Output RiskEvent JSONL file.
+        #[arg(long)]
+        out: PathBuf,
+    },
+}
+
+pub fn run(cmd: EvaluateCommand) -> Result<(), Box<dyn std::error::Error>> {
+    match cmd {
+        EvaluateCommand::Run { input, profile, out } => run_evaluate(input, profile, out),
+    }
+}
+
+fn run_evaluate(input: PathBuf, profile: PathBuf, out: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let rules = load_profile(&profile)
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    let file = fs::File::open(&input)?;
+    let mut reader = JsonlReader::open(file)
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    let frames: Vec<EntityFrame> = reader
+        .records()
+        .collect::<Result<Vec<_>, String>>()
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    let out_file = fs::File::create(&out)?;
+    let mut writer = JsonlWriter::new(out_file, "eds.risk-event", "0.1")
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    let mut total_events = 0usize;
+    for frame in &frames {
+        let events: Vec<RiskEvent> =
+            evaluate(&rules, &frame.entities, frame.timestamp_ms);
+        for event in &events {
+            writer.write_record(event)
+                .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+            total_events += 1;
+        }
+    }
+
+    eprintln!(
+        "evaluate run: {} event(s) from {} frame(s) written to {}",
+        total_events,
+        frames.len(),
+        out.display()
+    );
+    Ok(())
+}

--- a/crates/eds/src/ingest.rs
+++ b/crates/eds/src/ingest.rs
@@ -1,0 +1,56 @@
+//! `eds ingest` subcommands — entity ingestion pipeline.
+
+use clap::Subcommand;
+use std::fs;
+use std::path::PathBuf;
+
+use edgesentry_ingest::csv_replay::FileReplayAdapter;
+use edgesentry_ingest::jsonl::JsonlWriter;
+
+#[derive(Debug, Subcommand)]
+pub enum IngestCommand {
+    /// Replay entities from a CSV file and write EntityFrame JSONL.
+    Replay {
+        /// Input CSV file (id,class,x,y,vx,vy,timestamp_ms).
+        #[arg(long)]
+        source: PathBuf,
+
+        /// Profile directory (reserved for future use).
+        #[arg(long)]
+        profile: Option<PathBuf>,
+
+        /// Output JSONL file path.
+        #[arg(long)]
+        out: PathBuf,
+    },
+}
+
+pub fn run(cmd: IngestCommand) -> Result<(), Box<dyn std::error::Error>> {
+    match cmd {
+        IngestCommand::Replay { source, profile: _, out } => run_replay(source, out),
+    }
+}
+
+fn run_replay(source: PathBuf, out: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let content = fs::read_to_string(&source)?;
+
+    let adapter = FileReplayAdapter::from_csv(&content)
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let frames = adapter.frames();
+
+    let file = fs::File::create(&out)?;
+    let mut writer = JsonlWriter::new(file, "eds.entity-frame", "0.1")
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+
+    for frame in frames {
+        writer.write_record(frame)
+            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    }
+
+    eprintln!(
+        "ingest replay: wrote {} frame(s) to {}",
+        frames.len(),
+        out.display()
+    );
+    Ok(())
+}

--- a/crates/eds/src/main.rs
+++ b/crates/eds/src/main.rs
@@ -7,17 +7,26 @@
 //! eds audit keygen
 //! eds audit sign-record --device-id dev-01 ...
 //! eds audit verify-chain --records-file records.json
+//! eds ingest replay --source FILE --out FILE
+//! eds profile validate --profile DIR
+//! eds profile list --profile DIR
+//! eds compute run --input FILE --out FILE
+//! eds evaluate run --input FILE --profile DIR --out FILE
 //! ```
 
 mod audit;
 mod inspect;
+mod ingest;
+mod profile;
+mod compute;
+mod evaluate;
 
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(
     name = "eds",
-    about = "EdgeSentry CLI — IFC deviation analysis and tamper-evident audit trail",
+    about = "EdgeSentry CLI — IFC deviation analysis, tamper-evident audit trail, and safety evaluation",
     version
 )]
 struct Cli {
@@ -37,6 +46,26 @@ enum Commands {
         #[command(subcommand)]
         command: Box<audit::AuditCommand>,
     },
+    /// Entity data ingestion — CSV replay and JSONL output
+    Ingest {
+        #[command(subcommand)]
+        command: ingest::IngestCommand,
+    },
+    /// Profile management — validate and list rules
+    Profile {
+        #[command(subcommand)]
+        command: profile::ProfileCommand,
+    },
+    /// Physics computations — distance, TTC, braking distance
+    Compute {
+        #[command(subcommand)]
+        command: compute::ComputeCommand,
+    },
+    /// Rule evaluation — evaluate rules against entity frames
+    Evaluate {
+        #[command(subcommand)]
+        command: evaluate::EvaluateCommand,
+    },
 }
 
 fn main() {
@@ -45,6 +74,10 @@ fn main() {
     let result = match cli.command {
         Commands::Inspect { command } => inspect::run(command),
         Commands::Audit { command } => audit::run(*command),
+        Commands::Ingest { command } => ingest::run(command),
+        Commands::Profile { command } => profile::run(command),
+        Commands::Compute { command } => compute::run(command),
+        Commands::Evaluate { command } => evaluate::run(command),
     };
 
     if let Err(e) = result {

--- a/crates/eds/src/profile.rs
+++ b/crates/eds/src/profile.rs
@@ -1,0 +1,68 @@
+//! `eds profile` subcommands — profile validation and listing.
+
+use clap::Subcommand;
+use std::path::PathBuf;
+
+use edgesentry_profile::{load_profile, validate_profile};
+
+#[derive(Debug, Subcommand)]
+pub enum ProfileCommand {
+    /// Validate a profile directory.
+    Validate {
+        /// Profile directory containing rules.json (and optionally kb/).
+        #[arg(long)]
+        profile: PathBuf,
+    },
+
+    /// List rule IDs defined in a profile.
+    List {
+        /// Profile directory containing rules.json.
+        #[arg(long)]
+        profile: PathBuf,
+    },
+}
+
+pub fn run(cmd: ProfileCommand) -> Result<(), Box<dyn std::error::Error>> {
+    match cmd {
+        ProfileCommand::Validate { profile } => run_validate(profile),
+        ProfileCommand::List { profile } => run_list(profile),
+    }
+}
+
+fn run_validate(profile: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let report = validate_profile(&profile);
+
+    for w in &report.warnings {
+        eprintln!("warning: {w}");
+    }
+    for e in &report.errors {
+        eprintln!("error: {e}");
+    }
+
+    if report.is_valid() {
+        if report.warnings.is_empty() {
+            println!("Profile is valid.");
+        } else {
+            println!(
+                "Profile is valid with {} warning(s).",
+                report.warnings.len()
+            );
+        }
+        Ok(())
+    } else {
+        Err(format!(
+            "{} error(s), {} warning(s). Profile is invalid.",
+            report.errors.len(),
+            report.warnings.len()
+        ).into())
+    }
+}
+
+fn run_list(profile: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    let rules = load_profile(&profile)
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    for rule in &rules {
+        println!("{}", rule.rule_id);
+    }
+    Ok(())
+}

--- a/crates/eds/tests/cli_integration.rs
+++ b/crates/eds/tests/cli_integration.rs
@@ -354,6 +354,7 @@ fn demo_lift_inspection_writes_payloads_file_when_requested() {
 /// Bind an ephemeral port, drop the listener, and return the address string.
 /// The port is free for the next bind — there is a brief TOCTOU window but
 /// it is acceptable for test use.
+#[cfg(feature = "transport-http")]
 fn free_addr() -> String {
     let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     l.local_addr().unwrap().to_string()
@@ -361,6 +362,7 @@ fn free_addr() -> String {
 
 /// Poll TCP connect until the address is accepting connections or the timeout
 /// elapses.  Returns `true` if the server became ready in time.
+#[cfg(feature = "transport-http")]
 fn wait_for_tcp(addr: &str, timeout_secs: u64) -> bool {
     let deadline =
         std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);


### PR DESCRIPTION
## Summary

Implements #267 — Phase 1 of the edgesentry-rs migration roadmap.

Migrates the edgesentry-clarus engine from the `clarus` repo into four new crates in this workspace, adds five new `eds` CLI subcommands, and fixes a pre-existing dead code warning.

## New crates

| Crate | Contents |
|---|---|
| `edgesentry-ingest` | `Entity` / `Vec2` / `EntityClass` with Serde; `JsonlReader` / `JsonlWriter` with header versioning; `FileReplayAdapter` (CSV replay); `EntityFrame` schema |
| `edgesentry-compute` | `euclidean_distance`, `relative_velocity`, `braking_distance`, `time_to_collision`, `zone_membership` |
| `edgesentry-evaluate` | `Rule`, `RiskEvent`, `Severity`, `load_rules`, `evaluate` — all pipeline types now `Serialize + Deserialize` |
| `edgesentry-profile` | `validate_profile`, `load_profile`, `ValidationReport` |

## New `eds` subcommands

```
eds ingest replay  --source FILE [--profile DIR] --out FILE
eds profile validate --profile DIR
eds profile list     --profile DIR
eds compute run    --input FILE --out FILE
eds evaluate run   --input FILE --profile DIR --out FILE
```

## e2e pipeline (M3 exit criteria met)

```bash
eds ingest replay --source fixtures/forklift_approach.csv --profile profiles/demo --out /tmp/frames.jsonl
eds compute run   --input /tmp/frames.jsonl --out /tmp/measurements.jsonl
eds evaluate run  --input /tmp/frames.jsonl --profile profiles/demo --out /tmp/events.jsonl
```

## Also fixed

- Dead code warnings on `free_addr` and `wait_for_tcp` in `crates/eds/tests/cli_integration.rs` — both are only called inside `#[cfg(feature = "transport-http")]` tests; added matching `cfg` gates.

## Test plan

- [x] `cargo test --workspace` — 320 tests, 0 failures, 0 warnings
- [x] All original clarus tests ported verbatim (imports updated only)
- [x] `eds evaluate run` on `fixtures/forklift_approach.csv` fires PROXIMITY_ALERT and TTC_ALERT
- [x] `eds profile validate profiles/demo` exits 0
- [x] `JsonlReader` / `JsonlWriter` round-trip with schema header

🤖 Generated with [Claude Code](https://claude.ai/claude-code)