### PR TITLE
ci: add dependabot.yml — fix Dependabot 'No Cargo.toml!' error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Problem

Dependabot was failing on every run with:

```
unknown_error | { "message": "No Cargo.toml!" }
```

This happened because no `dependabot.yml` existed. GitHub's auto-detection was scanning an incorrect path (not the workspace root).

## Fix

Add `.github/dependabot.yml` explicitly configuring:
- **`cargo`** ecosystem at `/` (workspace root where `Cargo.toml` lives)
- **`github-actions`** ecosystem for workflow action pin updates
- Weekly Monday schedule
- Patch updates grouped into a single PR to reduce noise

## Test

Dependabot will re-run automatically once this merges to `main`. No code changes.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)