### PR TITLE
sec: update rustls-webpki 0.103.10 → 0.103.13; ignore unfixable 0.101/0.102 advisories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,12 +119,24 @@ jobs:
         run: cargo audit --version 2>/dev/null || cargo install cargo-audit --locked
 
       - name: Run security audit
-        # RUSTSEC-2026-0049 (GHSA-pwjx-qhcg-rvj4): rustls-webpki CRL bug.
-        # Two affected instances, no patch available for either:
-        #   0.101.7 — AWS SDK → hyper-rustls 0.24 → rustls 0.21 (#125)
-        #   0.102.8 — rumqttc 0.25 → rustls 0.22 (#166)
-        # No CRL revocation calls in the codebase; unexploitable as-is.
-        run: cargo audit --ignore RUSTSEC-2026-0049
+        # rustls-webpki advisories affecting 0.101.7 and 0.102.8 — two pinned
+        # transitive versions that cannot be updated without upstream changes:
+        #   0.101.7 — AWS SDK → hyper-rustls 0.24 → rustls 0.21
+        #   0.102.8 — rumqttc 0.25 → rustls ^0.102
+        # The 0.103.x line is updated to 0.103.13 which patches all three.
+        # None of these code paths call CRL APIs or validate URI/wildcard names
+        # in user-controlled certificate fields — unexploitable as-is.
+        #
+        # RUSTSEC-2026-0049: CRL Distribution Point matching flaw (pre-0.103.10)
+        # RUSTSEC-2026-0098: URI SAN name constraints incorrectly accepted
+        # RUSTSEC-2026-0099: Wildcard name constraints incorrectly accepted
+        # RUSTSEC-2026-0104: Reachable panic in CRL parsing (pre-0.103.13)
+        run: >
+          cargo audit
+          --ignore RUSTSEC-2026-0049
+          --ignore RUSTSEC-2026-0098
+          --ignore RUSTSEC-2026-0099
+          --ignore RUSTSEC-2026-0104
 
   sast:
     name: SAST (Clippy + cargo-deny advisories)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,7 +3149,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3208,9 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -15,14 +15,18 @@ ignore = [
   # No direct call-site exposure in our code.
   { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile pulled in transitively by rustls 0.23 chain; no patch available. Functionality superseded by rustls-pki-types but not yet adopted by rustls." },
   # RUSTSEC-2026-0049 / GHSA-pwjx-qhcg-rvj4: rustls-webpki CRL Distribution
-  # Point matching flaw (CVSS 4.4).  Patched in 0.103.10; no 0.102.x backport
-  # exists.  rumqttc 0.25.1 (latest, main branch) requires rustls-webpki ^0.102
-  # for its use-rustls-no-provider feature and has not updated this constraint.
-  # The TLS handshake itself uses rustls-webpki 0.103.10 via tokio-rustls 0.26;
-  # the 0.102.8 copy surfaces only as the WebPki error type in rumqttc.
-  # Exploitation requires a compromised trusted CA.  Unblock by upgrading rumqttc
-  # once it bumps rustls-webpki to ^0.103.
-  { id = "RUSTSEC-2026-0049", reason = "No 0.102.x patch for rustls-webpki; fix is in 0.103.10, which rumqttc 0.25.x does not yet accept (requires ^0.102). Tracking upstream." },
+  # Point matching flaw. Removed from ignore list — 0.103.13 (now in lock file)
+  # patches this advisory. The 0.102.8 instance (rumqttc) was also affected but
+  # cargo-audit handles that via --ignore in ci.yml; cargo-deny no longer detects
+  # this advisory now that 0.103.13 satisfies it for the primary chain.
+  #
+  # New advisories (0.101.7 and 0.102.8 pinned by upstream — see ci.yml):
+  # RUSTSEC-2026-0098: URI SAN name constraints incorrectly accepted
+  { id = "RUSTSEC-2026-0098", reason = "Fixed in rustls-webpki 0.103.13 (updated). 0.101.7 (AWS SDK/rustls 0.21) and 0.102.8 (rumqttc) remain pinned by upstream — no 0.101.x or 0.102.x backport. No URI SAN validation in our code paths." },
+  # RUSTSEC-2026-0099: Wildcard name constraints incorrectly accepted
+  { id = "RUSTSEC-2026-0099", reason = "Fixed in rustls-webpki 0.103.13 (updated). 0.101.7 and 0.102.8 remain pinned by upstream. No wildcard SAN validation in our code paths." },
+  # RUSTSEC-2026-0104: Reachable panic in CRL parsing
+  { id = "RUSTSEC-2026-0104", reason = "Fixed in rustls-webpki 0.103.13 (updated). 0.101.7 and 0.102.8 remain pinned by upstream. No CRL revocation calls in our code paths." },
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

Fixes the cargo-audit and cargo-deny CI failures caused by three new rustls-webpki advisories (RUSTSEC-2026-0098, -0099, -0104).

## Changes

**`Cargo.lock`**: `rustls-webpki 0.103.10 → 0.103.13`
- Patches all three advisories for the primary 0.103.x dependency chain

**`ci.yml`**: add `--ignore` flags for the three new advisories
- `0.101.7` (AWS SDK → rustls 0.21) and `0.102.8` (rumqttc → rustls ^0.102) cannot be updated without upstream dependency bumps
- None of the affected code paths call CRL APIs or validate URI/wildcard SANs in user-controlled certificate fields

**`deny.toml`**: remove stale `RUSTSEC-2026-0049` entry; add 0098/0099/0104
- `RUSTSEC-2026-0049` was triggering `advisory-not-detected` warning after the 0.103.13 update resolved it
- Added the three new advisory ignores with rationale for the pinned instances

## Advisory breakdown

| Advisory | Description | 0.103.13 | 0.101.7 (AWS SDK) | 0.102.8 (rumqttc) |
|---|---|---|---|---|
| RUSTSEC-2026-0049 | CRL Distribution Point matching | ✓ resolved | — | — |
| RUSTSEC-2026-0098 | URI SAN name constraints | ✓ fixed | pinned → ignore | pinned → ignore |
| RUSTSEC-2026-0099 | Wildcard name constraints | ✓ fixed | pinned → ignore | pinned → ignore |
| RUSTSEC-2026-0104 | CRL parsing panic | ✓ fixed | pinned → ignore | pinned → ignore |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)