### PR TITLE
docs: fix Mermaid diagram -- vertical flow and load Mermaid JS

### DIFF
--- a/docs/pipeline/architecture.md
+++ b/docs/pipeline/architecture.md
@@ -3,7 +3,7 @@
 ## Pipeline flow
 
 ```mermaid
-flowchart LR
+flowchart TD
     SRC1["CSV / UDP\nentity stream"]
     SRC2["voyage CSV\ndocument data"]
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,9 @@ plugins:
             Requirements: 要件
             Scenarios: シナリオ
 
+extra_javascript:
+  - https://unpkg.com/mermaid@10/dist/mermaid.min.js
+
 markdown_extensions:
   - pymdownx.superfences:
       custom_fences:


### PR DESCRIPTION
## Summary

- `flowchart LR` -> `flowchart TD` so the pipeline diagram renders top-down (vertical) instead of left-right
- Adds Mermaid 10 via unpkg CDN in `extra_javascript` -- required for MkDocs Material 9.5 to actually render mermaid fences in the browser

Fixes: https://edgesentry.github.io/edgesentry-rs/architecture/ showing no diagram