### PR TITLE
feat(audit): eds audit sign-document / verify-document — DocumentAuditPayload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ dependencies = [
 name = "eds"
 version = "0.2.0"
 dependencies = [
+ "blake3",
  "clap",
  "ed25519-dalek",
  "edgesentry-assess",

--- a/crates/edgesentry-document/src/lib.rs
+++ b/crates/edgesentry-document/src/lib.rs
@@ -3,6 +3,68 @@ use std::collections::HashMap;
 use edgesentry_parse::DocumentEntity;
 use serde::{Deserialize, Serialize};
 
+/// Payload sealed into the audit chain for a generated compliance document.
+///
+/// Constructed from a [`FilledDocument`] immediately before signing.
+/// Contains no raw sensor data or document content — only structured metadata
+/// sufficient to prove what was generated and with what confidence.
+///
+/// `timestamp_ms` is intentionally absent: it is a property of the signing event
+/// stored in [`AuditRecord::timestamp_ms`], not of the document content. This
+/// ensures the same payload hash can be recomputed from the same [`FilledDocument`]
+/// at any point in time for verification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentAuditPayload {
+    pub record_type: String,
+    pub voyage_id: String,
+    pub template_id: String,
+    /// AI-generated or direct value for each field, sorted by key for determinism.
+    pub ai_field_values: Vec<(String, String)>,
+    /// Confidence score (0.0–1.0) per field, sorted by key for determinism.
+    pub confidence_flags: Vec<(String, f64)>,
+    /// Fields below the confidence threshold that required human review.
+    pub fields_flagged: Vec<String>,
+    pub review_required: bool,
+}
+
+/// Build a [`DocumentAuditPayload`] from a [`FilledDocument`].
+///
+/// All map fields are sorted by key to ensure deterministic serialisation —
+/// the same [`FilledDocument`] always produces the same BLAKE3 hash.
+pub fn build_audit_payload(doc: &FilledDocument) -> DocumentAuditPayload {
+    let mut ai_field_values: Vec<(String, String)> = doc
+        .fields
+        .iter()
+        .map(|(k, v)| (k.clone(), v.value.clone()))
+        .collect();
+    ai_field_values.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut confidence_flags: Vec<(String, f64)> = doc
+        .fields
+        .iter()
+        .map(|(k, v)| (k.clone(), v.confidence))
+        .collect();
+    confidence_flags.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut fields_flagged: Vec<String> = doc
+        .fields
+        .iter()
+        .filter(|(_, v)| v.flagged)
+        .map(|(k, _)| k.clone())
+        .collect();
+    fields_flagged.sort();
+
+    DocumentAuditPayload {
+        record_type: "document".to_string(),
+        voyage_id: doc.voyage_id.clone(),
+        template_id: doc.template.clone(),
+        ai_field_values,
+        confidence_flags,
+        fields_flagged,
+        review_required: doc.review_required,
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum FieldSource {
     Direct,
@@ -249,5 +311,59 @@ mod tests {
         assert!(rendered.contains("MV Test"));
         assert!(rendered.contains("23"));
         assert!(!rendered.contains("{{VESSEL_NAME}}"));
+    }
+
+    #[test]
+    fn build_audit_payload_voyage_and_template() {
+        let entity = make_entity("V001", Some("2027-03-01"), Some(23));
+        let doc = fill(&entity, "fal-form-1", None, 0.5).unwrap();
+        let payload = build_audit_payload(&doc);
+        assert_eq!(payload.record_type, "document");
+        assert_eq!(payload.voyage_id, "V001");
+        assert_eq!(payload.template_id, "fal-form-1");
+        assert!(!payload.review_required);
+        assert!(payload.fields_flagged.is_empty());
+    }
+
+    #[test]
+    fn build_audit_payload_fields_sorted_for_determinism() {
+        let entity = make_entity("V001", Some("2027-03-01"), Some(23));
+        let doc = fill(&entity, "fal-form-1", None, 0.5).unwrap();
+        let p1 = build_audit_payload(&doc);
+        let p2 = build_audit_payload(&doc);
+        // Same input must produce identical serialisation every call.
+        let b1 = serde_json::to_vec(&p1).unwrap();
+        let b2 = serde_json::to_vec(&p2).unwrap();
+        assert_eq!(b1, b2, "payload serialisation must be deterministic");
+        // Keys must be sorted.
+        let keys: Vec<&str> = p1.ai_field_values.iter().map(|(k, _)| k.as_str()).collect();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(keys, sorted, "ai_field_values must be sorted by key");
+    }
+
+    #[test]
+    fn build_audit_payload_flags_low_confidence_fields() {
+        let entity = make_entity("V003", Some("2027-03-01"), None); // crew_count missing
+        let doc = fill(&entity, "fal-form-1", None, 0.5).unwrap();
+        let payload = build_audit_payload(&doc);
+        assert!(payload.review_required);
+        assert!(payload.fields_flagged.contains(&"CREW_COUNT".to_string()));
+        // Confidence for flagged field is 0.0
+        let crew_conf = payload.confidence_flags.iter()
+            .find(|(k, _)| k == "CREW_COUNT")
+            .map(|(_, v)| *v);
+        assert_eq!(crew_conf, Some(0.0));
+    }
+
+    #[test]
+    fn build_audit_payload_is_json_serialisable() {
+        let entity = make_entity("V001", Some("2027-03-01"), Some(23));
+        let doc = fill(&entity, "fal-form-1", None, 0.5).unwrap();
+        let payload = build_audit_payload(&doc);
+        let json = serde_json::to_string(&payload).unwrap();
+        let round_tripped: DocumentAuditPayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_tripped.voyage_id, payload.voyage_id);
+        assert_eq!(round_tripped.template_id, payload.template_id);
     }
 }

--- a/crates/eds/Cargo.toml
+++ b/crates/eds/Cargo.toml
@@ -36,6 +36,7 @@ edgesentry-report   = { path = "../edgesentry-report" }
 edgesentry-parse    = { path = "../edgesentry-parse" }
 edgesentry-document = { path = "../edgesentry-document" }
 edgesentry-scenario = { path = "../edgesentry-scenario" }
+blake3        = { workspace = true }
 clap          = { workspace = true }
 ed25519-dalek = { workspace = true }
 hex           = { workspace = true }

--- a/crates/eds/src/audit.rs
+++ b/crates/eds/src/audit.rs
@@ -8,6 +8,8 @@ use edgesentry_audit::{
     parse_fixed_hex, sign_record, verify_chain_file, verify_chain_records, verify_record,
     write_record_json, write_records_json, AuditRecord,
 };
+use edgesentry_document::{build_audit_payload, FilledDocument};
+use edgesentry_ingest::jsonl::JsonlReader;
 
 #[derive(Debug, Subcommand)]
 pub enum AuditCommand {
@@ -115,6 +117,44 @@ pub enum AuditCommand {
         #[cfg(feature = "transport-mqtt-tls")]
         #[arg(long)]
         tls_ca_cert: Option<PathBuf>,
+    },
+    /// Sign a filled compliance document and produce a tamper-evident AuditRecord.
+    ///
+    /// Reads FilledDocument JSONL, builds a DocumentAuditPayload for each record,
+    /// serialises it to canonical JSON bytes, signs with Ed25519, and writes an
+    /// AuditRecord JSON array. Each document in the input produces one AuditRecord.
+    /// Records are chained: if --chain is provided the last record's hash is used
+    /// as prev_record_hash for the first new record.
+    SignDocument {
+        /// FilledDocument JSONL produced by `eds document fill`.
+        #[arg(long)]
+        payload: PathBuf,
+        /// Ed25519 private key hex (32 bytes = 64 hex chars).
+        #[arg(long)]
+        key: String,
+        /// Device / signer identifier written into the AuditRecord.
+        #[arg(long, default_value = "eds-document")]
+        device_id: String,
+        /// Existing AuditRecord JSON array to continue chaining from (optional).
+        #[arg(long)]
+        chain: Option<PathBuf>,
+        /// Output file for the new AuditRecord(s) JSON array.
+        #[arg(long)]
+        out: PathBuf,
+    },
+    /// Verify that a filled document matches its AuditRecord in the chain.
+    ///
+    /// Rebuilds the DocumentAuditPayload from FilledDocument JSONL, computes its
+    /// BLAKE3 hash, and finds the matching AuditRecord in the chain. Prints a
+    /// human-readable trace: voyage_id, template, fields, confidence, flagged
+    /// fields, timestamp. Exits non-zero if no matching record is found.
+    VerifyDocument {
+        /// FilledDocument JSONL to verify (same file passed to sign-document).
+        #[arg(long)]
+        payload: PathBuf,
+        /// AuditRecord JSON array to search (output of sign-document).
+        #[arg(long)]
+        chain: PathBuf,
     },
     #[cfg(all(feature = "s3", feature = "postgres"))]
     /// Ingest records into PostgreSQL + MinIO (requires s3,postgres features)
@@ -479,6 +519,112 @@ pub fn run(cmd: AuditCommand) -> Result<(), Box<dyn std::error::Error>> {
             }
 
             println!("INGEST_COMPLETE: accepted={accepted} rejected={rejected}");
+        }
+
+        AuditCommand::SignDocument { payload, key, device_id, chain, out } => {
+            // Read existing chain to determine starting sequence and prev_hash.
+            let (mut sequence, mut prev_hash) = if let Some(ref chain_path) = chain {
+                let existing: Vec<AuditRecord> =
+                    serde_json::from_str(&std::fs::read_to_string(chain_path)?)?;
+                let seq = existing.last().map(|r| r.sequence + 1).unwrap_or(1);
+                let ph = existing.last().map(|r| r.hash()).unwrap_or(AuditRecord::zero_hash());
+                (seq, ph)
+            } else {
+                (1u64, AuditRecord::zero_hash())
+            };
+
+            // Read FilledDocument JSONL (skip schema header via JsonlReader).
+            let file = std::fs::File::open(&payload)?;
+            let mut reader = JsonlReader::open(file)
+                .map_err(|e| format!("JSONL open: {e}"))?;
+            let docs: Vec<FilledDocument> = reader
+                .records()
+                .collect::<Result<_, _>>()
+                .map_err(|e| Box::<dyn std::error::Error>::from(format!("JSONL read: {e}")))?;
+
+            let mut records: Vec<AuditRecord> = Vec::with_capacity(docs.len());
+            let timestamp_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+
+            for doc in &docs {
+                let audit_payload = build_audit_payload(doc);
+                let payload_bytes = serde_json::to_vec(&audit_payload)?;
+                let object_ref = format!("document:{}/{}", doc.voyage_id, doc.template);
+                let record = sign_record(
+                    device_id.clone(),
+                    sequence,
+                    timestamp_ms,
+                    payload_bytes,
+                    prev_hash,
+                    object_ref,
+                    &key,
+                )?;
+                prev_hash = record.hash();
+                sequence += 1;
+                records.push(record);
+            }
+
+            write_records_json(&out, &records)?;
+            println!("SIGNED: {} document record(s) written to {}", records.len(), out.display());
+        }
+
+        AuditCommand::VerifyDocument { payload, chain } => {
+            // Read FilledDocument JSONL (skip schema header via JsonlReader).
+            let file = std::fs::File::open(&payload)?;
+            let mut reader = JsonlReader::open(file)
+                .map_err(|e| format!("JSONL open: {e}"))?;
+            let docs: Vec<FilledDocument> = reader
+                .records()
+                .collect::<Result<_, _>>()
+                .map_err(|e| Box::<dyn std::error::Error>::from(format!("JSONL read: {e}")))?;
+
+            // Read audit chain.
+            let chain_content = std::fs::read_to_string(&chain)?;
+            let records: Vec<AuditRecord> = serde_json::from_str(&chain_content)?;
+
+            let mut found_any = false;
+            for doc in &docs {
+                let audit_payload = build_audit_payload(doc);
+                let payload_bytes = serde_json::to_vec(&audit_payload)?;
+                let payload_hash = *blake3::hash(&payload_bytes).as_bytes();
+
+                let matched = records.iter().find(|r| r.payload_hash == payload_hash);
+                match matched {
+                    Some(record) => {
+                        found_any = true;
+                        println!("VERIFIED");
+                        println!("  voyage_id:       {}", audit_payload.voyage_id);
+                        println!("  template:        {}", audit_payload.template_id);
+                        println!("  timestamp_ms:    {}", record.timestamp_ms);
+                        println!("  sequence:        {}", record.sequence);
+                        println!("  device_id:       {}", record.device_id);
+                        println!("  review_required: {}", audit_payload.review_required);
+                        if !audit_payload.fields_flagged.is_empty() {
+                            println!("  fields_flagged:  {}", audit_payload.fields_flagged.join(", "));
+                        }
+                        println!("  field confidence:");
+                        for (field, conf) in &audit_payload.confidence_flags {
+                            let flag = if audit_payload.fields_flagged.contains(field) { " [FLAGGED]" } else { "" };
+                            println!("    {:<30} {:.2}{}", field, conf, flag);
+                        }
+                        println!("  payload_hash:    {}", hex::encode(record.payload_hash));
+                    }
+                    None => {
+                        eprintln!(
+                            "NOT FOUND: no AuditRecord matches voyage_id={} template={}",
+                            doc.voyage_id, doc.template
+                        );
+                        std::process::exit(2);
+                    }
+                }
+            }
+
+            if !found_any {
+                eprintln!("NO DOCUMENTS: payload file contained no FilledDocument records");
+                std::process::exit(2);
+            }
         }
     }
 

--- a/crates/eds/tests/cli_integration.rs
+++ b/crates/eds/tests/cli_integration.rs
@@ -7,7 +7,10 @@ use std::{
     fs,
     path::PathBuf,
     process::{Command, Output},
+    sync::atomic::{AtomicUsize, Ordering},
 };
+
+static FILE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -726,4 +729,163 @@ fn missing_required_arg_exits_nonzero() {
         .output()
         .expect("sign-record missing --device-id");
     assert!(!out.status.success());
+}
+
+// ── sign-document / verify-document ──────────────────────────────────────────
+
+fn voyage_v001_csv() -> PathBuf {
+    workspace_path("crates/edgesentry-document/fixtures/voyage_V001_compliant.csv")
+}
+
+fn voyage_v002_csv() -> PathBuf {
+    workspace_path("crates/edgesentry-document/fixtures/voyage_V002_bwm_expired.csv")
+}
+
+/// Run `eds parse maritime` + `eds document fill` and return the resulting
+/// `filled.jsonl` temp file. The intermediate `entity.jsonl` is cleaned up
+/// when the returned `TmpFile` pair is dropped.
+///
+/// Uses the thread ID in filenames to avoid collisions between parallel tests.
+fn build_filled_document(csv: &std::path::Path) -> (TmpFile, TmpFile) {
+    let n = FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tid = format!("{:?}", std::thread::current().id())
+        .replace("ThreadId(", "").replace(")", "");
+    let entity = TmpFile::new(&format!("entity_{tid}_{n}.jsonl"));
+    let filled = TmpFile::new(&format!("filled_{tid}_{n}.jsonl"));
+
+    let parse_out = eds()
+        .args(["parse", "maritime", "--source"])
+        .arg(csv)
+        .arg("--out").arg(entity.path())
+        .output()
+        .expect("eds parse maritime");
+    assert!(parse_out.status.success(), "parse failed: {}", stderr(&parse_out));
+
+    let fill_out = eds()
+        .args(["document", "fill", "--input"])
+        .arg(entity.path())
+        .args(["--template", "fal-form-1", "--out"])
+        .arg(filled.path())
+        .output()
+        .expect("eds document fill");
+    assert!(fill_out.status.success(), "fill failed: {}", stderr(&fill_out));
+
+    (entity, filled)
+}
+
+#[test]
+fn sign_document_exits_zero_and_writes_audit_record() {
+    let (_entity, filled) = build_filled_document(&voyage_v001_csv());
+    let record = TmpFile::new("record.json");
+
+    let out = eds()
+        .args(["audit", "sign-document", "--payload"])
+        .arg(filled.path())
+        .args(["--key", PRIV_HEX, "--out"])
+        .arg(record.path())
+        .output()
+        .expect("eds audit sign-document");
+
+    assert!(out.status.success(), "sign-document failed: {}", stderr(&out));
+    assert!(stdout(&out).contains("SIGNED"), "stdout must say SIGNED");
+    assert!(stdout(&out).contains("1 document record"), "must report 1 record");
+
+    // Output must be valid JSON array of AuditRecord(s).
+    let content = fs::read_to_string(record.path()).expect("read record.json");
+    let records: Vec<serde_json::Value> = serde_json::from_str(&content)
+        .expect("record.json must be a JSON array");
+    assert_eq!(records.len(), 1);
+    assert!(records[0]["payload_hash"].is_array(), "payload_hash must be present");
+    assert_eq!(records[0]["sequence"].as_u64(), Some(1));
+}
+
+#[test]
+fn verify_document_prints_verified_for_matching_payload() {
+    let (_entity, filled) = build_filled_document(&voyage_v001_csv());
+    let record = TmpFile::new("record.json");
+
+    eds().args(["audit", "sign-document", "--payload"])
+        .arg(filled.path())
+        .args(["--key", PRIV_HEX, "--out"]).arg(record.path())
+        .output().expect("sign-document");
+
+    let out = eds()
+        .args(["audit", "verify-document", "--payload"])
+        .arg(filled.path())
+        .args(["--chain"]).arg(record.path())
+        .output()
+        .expect("eds audit verify-document");
+
+    assert!(out.status.success(), "verify-document failed: {}", stderr(&out));
+    let s = stdout(&out);
+    assert!(s.contains("VERIFIED"), "must print VERIFIED");
+    assert!(s.contains("V001"), "must include voyage_id");
+    assert!(s.contains("fal-form-1"), "must include template");
+    assert!(s.contains("VESSEL_NAME"), "must list field confidence");
+}
+
+#[test]
+fn verify_document_exits_nonzero_when_payload_not_in_chain() {
+    // Sign V001, then try to verify V002 against that chain — must fail.
+    let (_e1, filled_v001) = build_filled_document(&voyage_v001_csv());
+    let (_e2, filled_v002) = build_filled_document(&voyage_v002_csv());
+    let record = TmpFile::new("record.json");
+
+    eds().args(["audit", "sign-document", "--payload"])
+        .arg(filled_v001.path())
+        .args(["--key", PRIV_HEX, "--out"]).arg(record.path())
+        .output().expect("sign-document");
+
+    let out = eds()
+        .args(["audit", "verify-document", "--payload"])
+        .arg(filled_v002.path())  // different document
+        .args(["--chain"]).arg(record.path())
+        .output()
+        .expect("eds audit verify-document mismatch");
+
+    assert!(!out.status.success(), "must exit non-zero when not found");
+    assert!(stderr(&out).contains("NOT FOUND"), "must print NOT FOUND");
+}
+
+#[test]
+fn sign_document_chains_sequence_and_prev_hash() {
+    let (_e1, filled_v001) = build_filled_document(&voyage_v001_csv());
+    let (_e2, filled_v002) = build_filled_document(&voyage_v002_csv());
+    let chain1 = TmpFile::new("chain1.json");
+    let chain2 = TmpFile::new("chain2.json");
+
+    // Sign V001 — sequence 1.
+    eds().args(["audit", "sign-document", "--payload"])
+        .arg(filled_v001.path())
+        .args(["--key", PRIV_HEX, "--out"]).arg(chain1.path())
+        .output().expect("sign V001");
+
+    // Sign V002 continuing from chain1 — sequence must be 2.
+    let out = eds()
+        .args(["audit", "sign-document", "--payload"])
+        .arg(filled_v002.path())
+        .args(["--key", PRIV_HEX, "--chain"]).arg(chain1.path())
+        .args(["--out"]).arg(chain2.path())
+        .output()
+        .expect("sign V002 chained");
+
+    assert!(out.status.success(), "{}", stderr(&out));
+
+    let records: Vec<serde_json::Value> =
+        serde_json::from_str(&fs::read_to_string(chain2.path()).unwrap()).unwrap();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0]["sequence"].as_u64(), Some(2), "chained record must have sequence 2");
+
+    // prev_record_hash must NOT be all zeros (i.e. it was taken from chain1).
+    let prev: Vec<u8> = serde_json::from_value(records[0]["prev_record_hash"].clone()).unwrap();
+    assert_ne!(prev, vec![0u8; 32], "prev_record_hash must reference chain1 record");
+
+    // Both V001 and V002 must now be verifiable against their own chains.
+    let v = eds()
+        .args(["audit", "verify-document", "--payload"])
+        .arg(filled_v002.path())
+        .args(["--chain"]).arg(chain2.path())
+        .output().expect("verify V002");
+    assert!(v.status.success(), "V002 must verify: {}", stderr(&v));
+    assert!(stdout(&v).contains("V002"), "must show V002 voyage_id");
 }

--- a/crates/eds/tests/cli_integration.rs
+++ b/crates/eds/tests/cli_integration.rs
@@ -776,7 +776,8 @@ fn build_filled_document(csv: &std::path::Path) -> (TmpFile, TmpFile) {
 #[test]
 fn sign_document_exits_zero_and_writes_audit_record() {
     let (_entity, filled) = build_filled_document(&voyage_v001_csv());
-    let record = TmpFile::new("record.json");
+    let n = FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let record = TmpFile::new(&format!("record_{n}.json"));
 
     let out = eds()
         .args(["audit", "sign-document", "--payload"])
@@ -802,7 +803,8 @@ fn sign_document_exits_zero_and_writes_audit_record() {
 #[test]
 fn verify_document_prints_verified_for_matching_payload() {
     let (_entity, filled) = build_filled_document(&voyage_v001_csv());
-    let record = TmpFile::new("record.json");
+    let n = FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let record = TmpFile::new(&format!("record_{n}.json"));
 
     eds().args(["audit", "sign-document", "--payload"])
         .arg(filled.path())
@@ -829,7 +831,8 @@ fn verify_document_exits_nonzero_when_payload_not_in_chain() {
     // Sign V001, then try to verify V002 against that chain — must fail.
     let (_e1, filled_v001) = build_filled_document(&voyage_v001_csv());
     let (_e2, filled_v002) = build_filled_document(&voyage_v002_csv());
-    let record = TmpFile::new("record.json");
+    let n = FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let record = TmpFile::new(&format!("record_{n}.json"));
 
     eds().args(["audit", "sign-document", "--payload"])
         .arg(filled_v001.path())
@@ -851,8 +854,9 @@ fn verify_document_exits_nonzero_when_payload_not_in_chain() {
 fn sign_document_chains_sequence_and_prev_hash() {
     let (_e1, filled_v001) = build_filled_document(&voyage_v001_csv());
     let (_e2, filled_v002) = build_filled_document(&voyage_v002_csv());
-    let chain1 = TmpFile::new("chain1.json");
-    let chain2 = TmpFile::new("chain2.json");
+    let n = FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let chain1 = TmpFile::new(&format!("chain1_{n}.json"));
+    let chain2 = TmpFile::new(&format!("chain2_{n}.json"));
 
     // Sign V001 — sequence 1.
     eds().args(["audit", "sign-document", "--payload"])

--- a/scripts/demo_document_audit.sh
+++ b/scripts/demo_document_audit.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BIN="$ROOT/target/debug/eds"
 FIXTURES="$ROOT/crates/edgesentry-document/fixtures"
-PROFILE="$ROOT/crates/edgesentry-profile/fixtures/sg-port-compliance/rules.json"
+PROFILE="$ROOT/crates/edgesentry-profile/fixtures/sg-port-compliance"
 TMPDIR_LOCAL="$(mktemp -d /tmp/eds_demo_doc_XXXXXX)"
 trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
 
@@ -66,7 +66,7 @@ echo "    $(wc -l < "$TMPDIR_LOCAL/filled1.jsonl") line(s) in filled1.jsonl"
 
 step "eds document check  →  compliance alerts"
 "$BIN" document check --input "$TMPDIR_LOCAL/filled1.jsonl" \
-  --rules "$PROFILE" --out "$TMPDIR_LOCAL/alerts1.jsonl"
+  --profile "$PROFILE" --out "$TMPDIR_LOCAL/alerts1.jsonl"
 ALERT_COUNT=$(python3 -c "
 import sys
 lines = [l for l in open('$TMPDIR_LOCAL/alerts1.jsonl') if l.strip() and not l.startswith('{\"eds_schema')]
@@ -100,7 +100,7 @@ step "eds parse maritime + eds document fill"
 
 step "eds document check  →  compliance alerts (expect BWM_D2_EXPIRED HIGH)"
 "$BIN" document check --input "$TMPDIR_LOCAL/filled2.jsonl" \
-  --rules "$PROFILE" --out "$TMPDIR_LOCAL/alerts2.jsonl" && \
+  --profile "$PROFILE" --out "$TMPDIR_LOCAL/alerts2.jsonl" && \
   python3 -c "
 import json, sys
 lines = [l for l in open('$TMPDIR_LOCAL/alerts2.jsonl') if l.strip() and not l.startswith('{\"eds_schema')]

--- a/scripts/demo_document_audit.sh
+++ b/scripts/demo_document_audit.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# demo_document_audit.sh — TC4: document compliance audit chain demo
+#
+# Demonstrates the full document audit pipeline:
+#   parse → fill → check → gen → sign-document → verify-document
+#
+# Maps to the PIER71 TC4 scenario: an AI-assisted port-entry document
+# (FAL Form 1) is generated, sealed into a tamper-evident audit chain,
+# and the chain is queried to produce a human-readable audit trace.
+#
+# Usage:
+#   ./scripts/demo_document_audit.sh              # all three voyages
+#   ./scripts/demo_document_audit.sh --no-pause   # CI / non-interactive
+#
+# Prerequisites:
+#   cargo build -p eds   (done automatically)
+#
+# Three test cases:
+#   V001  compliant voyage — all fields filled, no flags
+#   V002  expired BWM certificate — HIGH compliance alert, blocked
+#   V003  low confidence cargo description — review required
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/target/debug/eds"
+FIXTURES="$ROOT/crates/edgesentry-document/fixtures"
+PROFILE="$ROOT/crates/edgesentry-profile/fixtures/sg-port-compliance/rules.json"
+TMPDIR_LOCAL="$(mktemp -d /tmp/eds_demo_doc_XXXXXX)"
+trap 'rm -rf "$TMPDIR_LOCAL"' EXIT
+
+NO_PAUSE=false
+for arg in "$@"; do [[ "$arg" == "--no-pause" ]] && NO_PAUSE=true; done
+
+pause() {
+    $NO_PAUSE && return
+    echo ""
+    read -rp "  [press Enter to continue] " _
+}
+
+header() { echo ""; echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; echo "  $1"; echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"; }
+step()   { echo ""; echo "  ▶ $1"; }
+
+# ── Build ────────────────────────────────────────────────────────────────────
+header "Building eds…"
+cargo build -p eds --quiet 2>&1 | tail -1
+
+# ── Keypair ───────────────────────────────────────────────────────────────────
+header "Setup — generate signing keypair"
+KEYPAIR=$("$BIN" audit keygen)
+KEY=$(echo "$KEYPAIR" | python3 -c "import sys,json; print(json.load(sys.stdin)['private_key_hex'])")
+echo "  private_key: ${KEY:0:16}…  (first 8 bytes shown)"
+
+# ── TC1: compliant voyage ─────────────────────────────────────────────────────
+header "TC1 — Compliant voyage (V001)"
+
+step "eds parse maritime  →  entity.jsonl"
+"$BIN" parse maritime --source "$FIXTURES/voyage_V001_compliant.csv" \
+  --out "$TMPDIR_LOCAL/entity1.jsonl"
+echo "    $(wc -l < "$TMPDIR_LOCAL/entity1.jsonl") line(s) in entity1.jsonl"
+
+step "eds document fill  →  filled.jsonl"
+"$BIN" document fill --input "$TMPDIR_LOCAL/entity1.jsonl" \
+  --template fal-form-1 --out "$TMPDIR_LOCAL/filled1.jsonl"
+echo "    $(wc -l < "$TMPDIR_LOCAL/filled1.jsonl") line(s) in filled1.jsonl"
+
+step "eds document check  →  compliance alerts"
+"$BIN" document check --input "$TMPDIR_LOCAL/filled1.jsonl" \
+  --rules "$PROFILE" --out "$TMPDIR_LOCAL/alerts1.jsonl"
+ALERT_COUNT=$(python3 -c "
+import sys
+lines = [l for l in open('$TMPDIR_LOCAL/alerts1.jsonl') if l.strip() and not l.startswith('{\"eds_schema')]
+print(len(lines))
+" 2>/dev/null || echo 0)
+echo "    compliance alerts: $ALERT_COUNT  (expected: 0)"
+
+step "eds document gen  →  fal-form-1.html"
+"$BIN" document gen --input "$TMPDIR_LOCAL/filled1.jsonl" \
+  --template fal-form-1 --out "$TMPDIR_LOCAL/fal-form-1.html"
+echo "    $(wc -c < "$TMPDIR_LOCAL/fal-form-1.html") bytes rendered"
+
+step "eds audit sign-document  →  record.json"
+"$BIN" audit sign-document --payload "$TMPDIR_LOCAL/filled1.jsonl" \
+  --key "$KEY" --out "$TMPDIR_LOCAL/record.json"
+
+step "eds audit verify-document  →  audit trace"
+"$BIN" audit verify-document --payload "$TMPDIR_LOCAL/filled1.jsonl" \
+  --chain "$TMPDIR_LOCAL/record.json"
+
+pause
+
+# ── TC2: expired BWM certificate ──────────────────────────────────────────────
+header "TC2 — Expired BWM certificate (V002)"
+
+step "eds parse maritime + eds document fill"
+"$BIN" parse maritime --source "$FIXTURES/voyage_V002_bwm_expired.csv" \
+  --out "$TMPDIR_LOCAL/entity2.jsonl"
+"$BIN" document fill --input "$TMPDIR_LOCAL/entity2.jsonl" \
+  --template fal-form-1 --out "$TMPDIR_LOCAL/filled2.jsonl"
+
+step "eds document check  →  compliance alerts (expect BWM_D2_EXPIRED HIGH)"
+"$BIN" document check --input "$TMPDIR_LOCAL/filled2.jsonl" \
+  --rules "$PROFILE" --out "$TMPDIR_LOCAL/alerts2.jsonl" && \
+  python3 -c "
+import json, sys
+lines = [l for l in open('$TMPDIR_LOCAL/alerts2.jsonl') if l.strip() and not l.startswith('{\"eds_schema')]
+for l in lines: a = json.loads(l); print(f'    [{a[\"severity\"]}] {a[\"rule_id\"]} — {a[\"regulation\"]}')
+"
+
+step "eds audit sign-document  →  chain continues from TC1"
+"$BIN" audit sign-document --payload "$TMPDIR_LOCAL/filled2.jsonl" \
+  --key "$KEY" --chain "$TMPDIR_LOCAL/record.json" \
+  --out "$TMPDIR_LOCAL/record2.json"
+
+step "eds audit verify-document  →  audit trace (sequence 2)"
+"$BIN" audit verify-document --payload "$TMPDIR_LOCAL/filled2.jsonl" \
+  --chain "$TMPDIR_LOCAL/record2.json"
+
+pause
+
+# ── TC3: low confidence ───────────────────────────────────────────────────────
+header "TC3 — Low confidence cargo description (V003)"
+
+step "eds parse maritime + eds document fill (threshold 0.80)"
+"$BIN" parse maritime --source "$FIXTURES/voyage_V003_low_confidence.csv" \
+  --out "$TMPDIR_LOCAL/entity3.jsonl"
+"$BIN" document fill --input "$TMPDIR_LOCAL/entity3.jsonl" \
+  --template fal-form-1 --confidence-threshold 0.80 \
+  --out "$TMPDIR_LOCAL/filled3.jsonl"
+
+step "eds audit sign-document  →  chain continues from TC2"
+"$BIN" audit sign-document --payload "$TMPDIR_LOCAL/filled3.jsonl" \
+  --key "$KEY" --chain "$TMPDIR_LOCAL/record2.json" \
+  --out "$TMPDIR_LOCAL/record3.json"
+
+step "eds audit verify-document  →  audit trace (sequence 3, flagged fields visible)"
+"$BIN" audit verify-document --payload "$TMPDIR_LOCAL/filled3.jsonl" \
+  --chain "$TMPDIR_LOCAL/record3.json"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+header "Demo complete"
+echo ""
+echo "  Three documents signed into a tamper-evident chain:"
+echo "    sequence 1  V001 (compliant)           → $TMPDIR_LOCAL/record.json"
+echo "    sequence 2  V002 (BWM_D2_EXPIRED HIGH) → $TMPDIR_LOCAL/record2.json"
+echo "    sequence 3  V003 (flagged fields)       → $TMPDIR_LOCAL/record3.json"
+echo ""
+echo "  Each AuditRecord links to the previous via prev_record_hash."
+echo "  Run  eds audit verify-chain  on any output file to check integrity."
+echo ""


### PR DESCRIPTION
## Summary

- **`eds audit sign-document`** — reads a `filled.jsonl` (JSONL schema-versioned), builds a deterministic `DocumentAuditPayload` (BLAKE3 hash of sorted fields, no timestamp in hashed content), signs it with Ed25519, appends to an optional existing chain via `prev_record_hash`
- **`eds audit verify-document`** — reads the same `filled.jsonl`, recomputes payload hash, finds matching `AuditRecord` in chain JSON, prints voyage/template/confidence table; exits 2 if not found
- **`DocumentAuditPayload`** — `Vec<(String, _)>` fields sorted by key for deterministic serialisation; `timestamp_ms` lives in `AuditRecord` only (not hashed)

## Tests

- 6 unit tests in `edgesentry-document` (fill, check, render, audit payload determinism)
- 4 CLI integration tests: sign exits 0, verify prints VERIFIED, mismatch exits non-zero, chain prev_record_hash links correctly
- `scripts/demo_document_audit.sh` — TC1 compliant, TC2 BWM expired HIGH alert, TC3 low-confidence flagged fields; three documents chained end-to-end

## Test plan

- [x] `cargo test -p edgesentry-document`
- [x] `cargo test -p eds --test cli_integration` (28 tests, all pass)
- [ ] Run `./scripts/demo_document_audit.sh --no-pause` end-to-end

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)