### PR TITLE
fix(docs): mkdocs nav and broken links after security/ restructure

### DIFF
--- a/docs/security/cls-traceability.md
+++ b/docs/security/cls-traceability.md
@@ -11,12 +11,12 @@ Legend:
 
 ## SS 711:2025 Design Principles Coverage
 
-Singapore's national IoT standard SS 711:2025 defines four principles. See the [Roadmap](roadmap.md) for the full module mapping.
+Singapore's national IoT standard SS 711:2025 defines four principles. See the [Roadmap](../audit/roadmap.md) for the full module mapping.
 
 | Principle | SS 711:2025 Requirement | Status |
 |-----------|------------------------|--------|
 | Secure by Default | Unique device identity, signed OTA updates | ✅ `identity.rs`, `update.rs` |
-| Rigour in Defence | STRIDE threat model, tamper detection | ✅ Hash chain (`integrity.rs`) + [STRIDE threat model](threat_model.md) |
+| Rigour in Defence | STRIDE threat model, tamper detection | ✅ Hash chain (`integrity.rs`) + [STRIDE threat model](threat-model.md) |
 | Accountability | Audit trail, operation logs, RBAC design | ✅ `ingest/` (AuditLedger, OperationLog) |
 | Resiliency | Deny-by-default networking, DoS protection | ✅ `ingest/network_policy.rs` |
 
@@ -70,7 +70,7 @@ Singapore's national IoT standard SS 711:2025 defines four principles. See the [
 | Implementation | Public key registry: `IntegrityPolicyGate::register_device` ([`src/ingest/policy.rs:20`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/ingest/policy.rs#L20)) |
 | Implementation | Key generation CLI: `eds keygen` ([`src/lib.rs — generate_keypair`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/lib.rs)) |
 | Implementation | Key inspection CLI: `eds inspect-key` ([`src/lib.rs — inspect_key`](https://github.com/edgesentry/edgesentry-rs/blob/main/crates/edgesentry-rs/src/lib.rs)) |
-| Implementation | Provisioning and rotation guidance: [Key Management](key_management.md) |
+| Implementation | Provisioning and rotation guidance: [Key Management](../audit/key_management.md) |
 | Note | HSM-backed key storage (CLS Level 4) is planned in [#54](https://github.com/edgesentry/edgesentry-rs/issues/54) |
 
 ---

--- a/docs/security/sbom.md
+++ b/docs/security/sbom.md
@@ -70,7 +70,7 @@ The IMDA IoT Cyber Security Guide requires responses across five categories. The
 | Algorithms used | Ed25519 (signing), BLAKE3 (hashing) |
 | Key length | Ed25519: 256-bit; BLAKE3 output: 256-bit |
 | Random number generation | OS CSPRNG via `rand::OsRng` — no custom RNG |
-| Transport encryption | Record-level: Ed25519 signature over payload hash. Native TLS transport is provided: `eds serve-tls --tls-cert / --tls-key` (rustls TLS 1.2/1.3, HTTP) and `eds serve-mqtt --tls-ca-cert` (MQTT over TLS). See [CLS-05 in the Traceability Matrix](traceability.md). |
+| Transport encryption | Record-level: Ed25519 signature over payload hash. Native TLS transport is provided: `eds serve-tls --tls-cert / --tls-key` (rustls TLS 1.2/1.3, HTTP) and `eds serve-mqtt --tls-ca-cert` (MQTT over TLS). See [CLS-05 in the Traceability Matrix](cls-traceability.md). |
 | Key storage | Public-key registry in memory (`IntegrityPolicyGate`); private key files managed by the deployer. HSM-backed storage planned: [#54](https://github.com/edgesentry/edgesentry-rs/issues/54) |
 | Implementation | `crates/edgesentry-rs/src/identity.rs`, `crates/edgesentry-rs/src/integrity.rs` |
 
@@ -113,7 +113,7 @@ The IMDA IoT Cyber Security Guide requires responses across five categories. The
 | SBOM availability | CycloneDX JSON published with every GitHub Release (see above) |
 | Dependency advisory scanning | `cargo-audit` on every CI build + PR against RustSec Advisory DB |
 | End-of-life policy | `edgesentry-rs` v0.x: current version supported. Security updates are patch releases |
-| Software update integrity | `UpdateVerifier` checks BLAKE3 payload hash and Ed25519 publisher signature before any update is applied — see [CLS-03](traceability.md) |
+| Software update integrity | `UpdateVerifier` checks BLAKE3 payload hash and Ed25519 publisher signature before any update is applied — see [CLS-03](cls-traceability.md) |
 | Supported versions | See [SECURITY.md](https://github.com/edgesentry/edgesentry-rs/blob/main/SECURITY.md#supported-versions) |
 | CLS reference | CLS-02 / ETSI EN 303 645 §5.2 |
 
@@ -121,4 +121,4 @@ The IMDA IoT Cyber Security Guide requires responses across five categories. The
 
 ## Traceability
 
-This document satisfies Milestone 1.4 in the [Roadmap](roadmap.md). For the full clause-by-clause compliance mapping see the [Compliance Traceability Matrix](traceability.md).
+This document satisfies Milestone 1.4 in the [Roadmap](../audit/roadmap.md). For the full clause-by-clause compliance mapping see the [Compliance Traceability Matrix](cls-traceability.md).

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -62,7 +62,7 @@ This document is a formal threat-modelling artifact produced for Singapore CLS L
 | M-S-2 | Monotonic sequence numbers and `prev_record_hash` chain continuity are enforced; replayed records are detected as duplicate sequences | `ingest/verify.rs` `check_sequence()` |
 | M-S-3 | Ed25519 signatures bind the payload hash to the private key; a forged `device_id` with the wrong key fails signature verification | `identity.rs` `verify_payload_signature()` |
 
-**Residual risk:** If a device's private key is physically extracted, records can be forged with valid signatures.  Hardware-backed key storage (TPM/SE) is a device-layer control outside the scope of this library; it is noted in the [Roadmap](roadmap.md).
+**Residual risk:** If a device's private key is physically extracted, records can be forged with valid signatures.  Hardware-backed key storage (TPM/SE) is a device-layer control outside the scope of this library; it is noted in the [Roadmap](../audit/roadmap.md).
 
 ---
 
@@ -136,7 +136,7 @@ This document is a formal threat-modelling artifact produced for Singapore CLS L
 | M-I-2 | Raw payloads are stored by `object_ref` under the caller-specified key; access control is enforced by the storage layer (S3 bucket policy, Postgres GRANT); the library does not expose read APIs to unauthenticated callers | `ingest/storage.rs` `RawDataStore::put()` |
 | M-I-3 | Error messages include `device_id` and `sequence` but never the raw payload bytes; `tracing` spans log `payload_bytes` length only | `ingest/storage.rs` `#[instrument(skip(raw_payload))]` |
 
-**Residual risk:** Encryption at rest for S3 objects and Postgres rows is a deployment-layer control (S3 SSE-KMS, Postgres `pgcrypto` or TDE).  TLS 1.3 for the ingest HTTP endpoint is addressed in the [Roadmap](roadmap.md) (issue #73).
+**Residual risk:** Encryption at rest for S3 objects and Postgres rows is a deployment-layer control (S3 SSE-KMS, Postgres `pgcrypto` or TDE).  TLS 1.3 for the ingest HTTP endpoint is addressed in the [Roadmap](../audit/roadmap.md) (issue #73).
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,13 @@ plugins:
             Background: 背景
             Requirements: 要件
             Scenarios: シナリオ
+            Security: セキュリティ
+            Overview: 概要
+            Threat Model: 脅威モデル
+            Traceability: トレーサビリティ
+            SBOM: SBOM
+            Legal: 法的要件
+            Admissibility: 証拠能力
 
 extra_javascript:
   - https://unpkg.com/mermaid@10/dist/mermaid.min.js
@@ -113,10 +120,14 @@ nav:
     - CLI Reference: audit/cli.md
     - Key Management: audit/key_management.md
     - Deployment: audit/deployment.md
-    - Threat Model: audit/threat_model.md
     - Operations Runbook: audit/operations.md
-    - Traceability: audit/traceability.md
-    - SBOM: audit/sbom.md
+  - Security:
+    - Overview: security/index.md
+    - Threat Model: security/threat-model.md
+    - Traceability: security/cls-traceability.md
+    - SBOM: security/sbom.md
+  - Legal:
+    - Admissibility: legal/index.md
   - Inspect:
     - Introduction: inspect/introduction.md
     - Background: inspect/background.md


### PR DESCRIPTION
## What broke

PR #311 moved `audit/threat_model.md`, `audit/traceability.md`, `audit/sbom.md` to `security/` but did not update:
- `mkdocs.yml` nav (still pointed to old `audit/` paths → docs build failed)
- Relative links inside the moved files (`roadmap.md`, `threat_model.md`, `key_management.md`, `traceability.md`)

## Fixes

- `mkdocs.yml`: replace old `audit/` nav entries with `security/threat-model.md`, `security/cls-traceability.md`, `security/sbom.md`; add **Security** and **Legal** sections; add Japanese nav translations
- `security/cls-traceability.md`: fix `roadmap.md` → `../audit/roadmap.md`, `threat_model.md` → `threat-model.md`, `key_management.md` → `../audit/key_management.md`
- `security/sbom.md`: fix `traceability.md` → `cls-traceability.md`, `roadmap.md` → `../audit/roadmap.md`
- `security/threat-model.md`: fix `roadmap.md` → `../audit/roadmap.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)