### PR TITLE
fix: mkdocs strict-mode warnings — broken link and missing nav entries

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -85,7 +85,7 @@ This document is a formal threat-modelling artifact produced for Singapore CLS L
 |----|-----------|---------------|
 | M-T-1 | On every ingest the cloud recomputes `BLAKE3(raw_payload)` and compares it to `record.payload_hash`; mismatch → `PayloadHashMismatch` rejection | `ingest/storage.rs` `IngestService::ingest()` |
 | M-T-2 | `payload_hash` is covered by the Ed25519 signature; if the hash is changed the signature no longer verifies | `identity.rs` `verify_payload_signature()` |
-| M-T-3 | Post-ingest tampering of stored objects is detectable by re-verifying the hash from the ledger against the object content; this is an operational control described in the [Operations Runbook](operations.md) |
+| M-T-3 | Post-ingest tampering of stored objects is detectable by re-verifying the hash from the ledger against the object content; this is an operational control described in the [Operations Runbook](../audit/operations.md) |
 | M-T-4 | `prev_record_hash` is validated against the previous accepted record's `hash()`; a break in continuity rejects all subsequent records | `ingest/verify.rs` `check_chain_link()` |
 
 **Residual risk:** Tampering of stored objects after acceptance is a storage-layer concern.  Enabling S3 Object Lock (WORM) or database row-level checksums at the deployment layer eliminates this residual.
@@ -132,7 +132,7 @@ This document is a formal threat-modelling artifact produced for Singapore CLS L
 
 | ID | Mitigation | Code location |
 |----|-----------|---------------|
-| M-I-1 | The HTTP transport is designed to run behind TLS termination (load balancer / Nginx / Cloudflare); raw payload is hex-encoded in the JSON body and must be carried over HTTPS | `transport/http.rs` — TLS is a deployment-layer control; noted in [Operations Runbook](operations.md) |
+| M-I-1 | The HTTP transport is designed to run behind TLS termination (load balancer / Nginx / Cloudflare); raw payload is hex-encoded in the JSON body and must be carried over HTTPS | `transport/http.rs` — TLS is a deployment-layer control; noted in [Operations Runbook](../audit/operations.md) |
 | M-I-2 | Raw payloads are stored by `object_ref` under the caller-specified key; access control is enforced by the storage layer (S3 bucket policy, Postgres GRANT); the library does not expose read APIs to unauthenticated callers | `ingest/storage.rs` `RawDataStore::put()` |
 | M-I-3 | Error messages include `device_id` and `sequence` but never the raw payload bytes; `tracing` spans log `payload_bytes` length only | `ingest/storage.rs` `#[instrument(skip(raw_payload))]` |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,9 @@ nav:
       - Step 7 - Seal: pipeline/step-7-seal.md
     - Scenario: pipeline/scenario.md
     - Profile Authoring: pipeline/profile-authoring.md
+    - CV Integration: pipeline/cv-integration.md
+    - Edge / Cloud Split: pipeline/edge-cloud-split.md
+    - Edge / Cloud Implementation: pipeline/edge-cloud-implementation.md
     - CLI Reference: pipeline/cli-reference.md
   - Audit:
     - Introduction: audit/introduction.md
@@ -128,6 +131,7 @@ nav:
     - SBOM: security/sbom.md
   - Legal:
     - Admissibility: legal/index.md
+  - Roadmap: roadmap/index.md
   - Inspect:
     - Introduction: inspect/introduction.md
     - Background: inspect/background.md


### PR DESCRIPTION
## Fixes

**1. Broken link in `security/threat-model.md` (caused the 2 strict-mode WARNINGs → exit code 1)**

`operations.md` resolved to `security/operations.md` which does not exist. Fixed to `../audit/operations.md` (the Operations Runbook lives under `audit/`). Both occurrences replaced.

**2. Missing nav entries in `mkdocs.yml`**

Four files existed in `docs/` but were not in the nav — MkDocs logged them as INFO but they were orphaned pages:

| File | Nav entry added |
|---|---|
| `pipeline/cv-integration.md` | CV Integration (under Pipeline) |
| `pipeline/edge-cloud-split.md` | Edge / Cloud Split (under Pipeline) |
| `pipeline/edge-cloud-implementation.md` | Edge / Cloud Implementation (under Pipeline) |
| `roadmap/index.md` | Roadmap (top-level) |