### PR TITLE
fix(audit): resolve rand_core version conflict with ed25519-dalek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,7 @@ dependencies = [
  "postcard",
  "postgres",
  "rand 0.9.4",
+ "rand_core 0.6.4",
  "rcgen",
  "reqwest",
  "rumqttc",
@@ -1389,6 +1390,7 @@ dependencies = [
  "ed25519-dalek",
  "edgesentry-audit",
  "rand 0.9.4",
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/crates/edgesentry-audit/Cargo.toml
+++ b/crates/edgesentry-audit/Cargo.toml
@@ -54,6 +54,7 @@ ed25519-dalek.workspace = true
 hex.workspace = true
 postcard.workspace = true
 rand.workspace = true
+rand_core = { version = "0.6", features = ["getrandom"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/edgesentry-audit/src/lib.rs
+++ b/crates/edgesentry-audit/src/lib.rs
@@ -34,7 +34,7 @@ pub use record::{AuditRecord, Hash32, Signature64};
 use std::{fs, path::Path};
 
 use ed25519_dalek::{SigningKey, VerifyingKey};
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/crates/edgesentry-bridge/Cargo.toml
+++ b/crates/edgesentry-bridge/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 edgesentry-audit = { path = "../edgesentry-audit" }
 ed25519-dalek.workspace = true
 rand.workspace = true
+rand_core = { version = "0.6", features = ["getrandom"] }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/crates/edgesentry-bridge/src/lib.rs
+++ b/crates/edgesentry-bridge/src/lib.rs
@@ -27,7 +27,7 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 use edgesentry_audit::{
     compute_payload_hash, sign_payload_hash, verify_chain, verify_payload_signature, AuditRecord,
 };
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 
 // ── Thread-local error storage ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `rand` was bumped to 0.9 (PR #367), which pulls in `rand_core` 0.9
- `ed25519-dalek` 2.x depends on `rand_core` 0.6; `SigningKey::generate` requires `rand_core` 0.6's `CryptoRngCore`
- `OsRng` from `rand::rngs` (now `rand_core` 0.9) does not satisfy the bound → compile error

Fix: add `rand_core = { version = "0.6", features = ["getrandom"] }` as a direct dependency and import `OsRng` from it directly, bypassing the version mismatch.

## Test plan

- [ ] `cargo build -p edgesentry-audit` passes
- [ ] `cargo clippy -p edgesentry-audit --all-targets --all-features -- -D warnings` passes
- [ ] CI green

Fixes https://github.com/edgesentry/edgesentry-rs/actions/runs/25358745649/job/74353392415

🤖 Generated with [Claude Code](https://claude.ai/claude-code)