### PR TITLE
ci(pages): host rustdoc API reference at /api/

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "crates/**"
+      - "src/**"
   workflow_dispatch:
 
 permissions:
@@ -25,13 +27,31 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install MkDocs dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install "mkdocs-material>=9.5,<10"
+      - uses: dtolnay/rust-toolchain@stable
 
-      - name: Build docs
+      - name: Cache cargo registry
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93a1d19  # v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Install MkDocs
+        run: pip install "mkdocs-material>=9.5,<10"
+
+      - name: Build MkDocs
         run: mkdocs build --strict
+
+      - name: Build rustdoc
+        run: cargo doc --workspace --no-deps --document-private-items
+
+      - name: Add rustdoc entry point
+        run: |
+          echo '<meta http-equiv="refresh" content="0; url=eds/index.html">' \
+            > target/doc/index.html
+
+      - name: Copy rustdoc into site/api/
+        run: cp -r target/doc site/api
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ Reusable Rust crates and CLI for sensor-to-seal compliance pipelines.
 - **[Architecture & Pipeline](pipeline/index.md)** — seven-stage pipeline, edge/cloud split, CV adapter contract
 - **[Security & Compliance](security/index.md)** — CLS Level 3/4, ETSI EN 303 645, JC-STAR evidence package
 - **[Roadmaps](roadmap/index.md)** — pipeline progress, inspect feature, SG/JP/EU compliance strategy
-- **[API Reference](api/index.html)** — rustdoc for all 18 crates
+- **[API Reference](https://edgesentry.github.io/edgesentry-rs/api/)** — rustdoc for all 18 crates
 
 ## Quick start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ Reusable Rust crates and CLI for sensor-to-seal compliance pipelines.
 - **[Architecture & Pipeline](pipeline/index.md)** — seven-stage pipeline, edge/cloud split, CV adapter contract
 - **[Security & Compliance](security/index.md)** — CLS Level 3/4, ETSI EN 303 645, JC-STAR evidence package
 - **[Roadmaps](roadmap/index.md)** — pipeline progress, inspect feature, SG/JP/EU compliance strategy
+- **[API Reference](api/index.html)** — rustdoc for all 18 crates
 
 ## Quick start
 

--- a/docs/security/index.md
+++ b/docs/security/index.md
@@ -32,4 +32,4 @@ edgesentry-rs targets the following certifications. Each document below is a dir
 
 - **[docs/roadmap/strategy-compliance.md](../roadmap/strategy-compliance.md)** — phased plan for SG → JP → EU market compliance
 - **[docs/legal.md](../legal.md)** — legal admissibility of audit records (Evidence Act, RFC 3161)
-- **[docs/pipeline/](../pipeline/)** — edge/cloud split and CV adapter contract
+- **[docs/pipeline/](../pipeline/index.md)** — edge/cloud split and CV adapter contract


### PR DESCRIPTION
## Summary

Adds rustdoc generation to the existing GitHub Pages deployment so both human docs and API reference are hosted together.

## URLs after merge

| URL | Content |
|---|---|
| `edgesentry.github.io/edgesentry-rs/` | mkdocs — architecture, security, roadmap |
| `edgesentry.github.io/edgesentry-rs/api/` | rustdoc — all 18 crates |

## Changes

**`pages.yml`**
- Add `dtolnay/rust-toolchain@stable` + cargo registry cache
- `cargo doc --workspace --no-deps --document-private-items`
- Entry point redirect: `target/doc/index.html` → `eds/index.html`
- Copy `target/doc/` → `site/api/` before upload
- Extend path trigger to include `crates/**` and `src/**` (docs rebuild on code changes)

**`docs/index.md`**
- Add link to `api/index.html`

## Note

`--document-private-items` is included so internal types are visible to contributors. Remove if public-only docs are preferred.