### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -12,6 +12,9 @@ on:
       - "docs/**"
       - "mkdocs.yml"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/edgesentry/edgesentry-rs/security/code-scanning/9](https://github.com/edgesentry/edgesentry-rs/security/code-scanning/9)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: set workflow-level permissions to `contents: read`, since the only token-relevant action is `actions/checkout`, which needs read access to repository contents. This avoids changing job behavior while satisfying CodeQL and hardening security.

Edit `.github/workflows/docs-check.yml` by inserting:

```yml
permissions:
  contents: read
```

near the top level (e.g., after the `on:` block and before `jobs:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
