### PR TITLE
fix(bridge): add zkp feature gate to fix --all-features CI failure

### DIFF
--- a/crates/edgesentry-audit/Cargo.toml
+++ b/crates/edgesentry-audit/Cargo.toml
@@ -49,7 +49,7 @@ buffer-sqlite = ["dep:rusqlite"]
 zkp = ["dep:edgesentry-zkp"]
 
 [dependencies]
-edgesentry-zkp = { path = "../edgesentry-zkp", optional = true }
+edgesentry-zkp = { path = "../edgesentry-zkp", version = "0.2.0", optional = true }
 blake3.workspace = true
 clap.workspace = true
 ed25519-dalek.workspace = true

--- a/crates/edgesentry-bridge/Cargo.toml
+++ b/crates/edgesentry-bridge/Cargo.toml
@@ -12,6 +12,9 @@ documentation = "https://edgesentry.github.io/edgesentry-rs/audit/ffi_bridge/"
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]
 
+[features]
+zkp = ["edgesentry-audit/zkp"]
+
 [dependencies]
 edgesentry-audit = { path = "../edgesentry-audit" }
 ed25519-dalek.workspace = true

--- a/crates/edgesentry-bridge/src/lib.rs
+++ b/crates/edgesentry-bridge/src/lib.rs
@@ -127,6 +127,8 @@ fn to_audit_record(r: &EdsAuditRecord) -> AuditRecord {
         signature: r.signature,
         prev_record_hash: r.prev_record_hash,
         object_ref: read_str_from_buf(&r.object_ref),
+        #[cfg(feature = "zkp")]
+        zk_proof: None,
     }
 }
 


### PR DESCRIPTION
## Summary

- CI was failing on every Dependabot PR with `error[E0063]: missing field 'zk_proof' in initializer of AuditRecord`
- Root cause: `edgesentry-audit/zkp` feature adds `zk_proof: Option<ZkProof>` to `AuditRecord`, but `to_audit_record()` in the bridge didn't initialize it
- CI's `--all-features` flag enabled `zkp` on `edgesentry-audit`, exposing the gap

## Fix

- Added `[features] zkp = ["edgesentry-audit/zkp"]` to `edgesentry-bridge/Cargo.toml`
- Added `#[cfg(feature = "zkp")] zk_proof: None` to the struct initializer in `to_audit_record()`

Verified: compiles cleanly both with and without `--features zkp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)