### PR TITLE
docs(audit): document eds audit export-aims — ISO/IEC 42001 A.4 evidence pack

### DIFF
--- a/docs/crates.md
+++ b/docs/crates.md
@@ -82,6 +82,24 @@ Each record hashes its payload and the previous record's hash. `eds audit verify
 
 Compliance targets: CLS Level 3 (SS 711:2025), JC-STAR, ETSI EN 303 645. See `docs/roadmap/strategy-compliance.md`.
 
+## eds audit export-aims
+
+**Input:** AuditRecord JSON array (`--chain`) · optional `RiskEvent` JSONL (`--events`) · optional profile directory (`--profile-dir`)
+
+**Output:** JSON evidence bundle (`--out`) · optional Markdown summary (`--md`)
+
+Maps the chain to ISO/IEC 42001 Annex A.4 controls:
+
+| Control | What is populated |
+|---|---|
+| A.4.2 Resource documentation | Record count, device IDs, timestamp range, chain validity, `object_ref` types |
+| A.4.3 Data resources | Unique `object_ref`s, rule IDs triggered, regulations referenced (from `--events`) |
+| A.4.4 Tooling resources | `eds` version, `edgesentry-evaluate` crate, rule count and IDs (from `--profile-dir`) |
+| A.4.5 System and computing resources | Phase 2 placeholder — see issue [#399](https://github.com/edgesentry/edgesentry-rs/issues/399) |
+| A.4.6 Human resources | `document:` object refs counted as HITL-reviewed records |
+
+All output includes a disclaimer: *control-aligned evidence for a customer's AIMS audit — not an ISO/IEC 42001 certificate.*
+
 # edgesentry-zkp
 
 Generic ZKP infrastructure — `ZkProgram` trait, `ZkProof` envelope, `ZkFramework` enum.

--- a/docs/roadmap/core-pipeline.md
+++ b/docs/roadmap/core-pipeline.md
@@ -58,6 +58,7 @@ is inspectable; the profiles are valuable because they require domain expertise.
 | 6a — Safety report | `edgesentry-report` | `eds report generate` | ✅ Markdown + PDF done |
 | 6b — Document compliance | `edgesentry-document` | `eds document fill / check / gen` | ✅ Done |
 | 7 — Seal | `edgesentry-audit` | `eds audit sign / verify` | ✅ Done |
+| 8 — Evidence export | `edgesentry-audit` | `eds audit export-aims` | ✅ Done ([#397](https://github.com/edgesentry/edgesentry-rs/issues/397)) |
 
 **Supporting crates:**
 


### PR DESCRIPTION
## Summary

- `docs/crates.md`: adds `export-aims` I/O contract and A.4.2–A.4.6 control mapping table to the `edgesentry-audit` section
- `docs/roadmap/core-pipeline.md`: adds step 8 (Evidence export) row to the pipeline table, linked to closed issue #397

## No code changes — docs only

Follows the implementation in PR #402 (`feat/audit-export-aims`).

## Test plan

- [x] Docs render correctly (Markdown tables, links valid)
- [x] Issue #397 link resolves to closed issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)