### PR TITLE
fix(inspect): advance trilink-core git rev to b8dada7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4817,7 +4817,7 @@ dependencies = [
 [[package]]
 name = "trilink-core"
 version = "0.1.1"
-source = "git+https://github.com/edgesentry/trilink-core.git?rev=72afa31#72afa31795b8d338134935434de534b90ccc965d"
+source = "git+https://github.com/edgesentry/trilink-core.git?rev=b8dada7ee696315d0b93f462c9ff27f001483dfd#b8dada7ee696315d0b93f462c9ff27f001483dfd"
 dependencies = [
  "glam",
  "serde",

--- a/crates/edgesentry-inspect/Cargo.toml
+++ b/crates/edgesentry-inspect/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
-trilink-core = { git = "https://github.com/edgesentry/trilink-core.git", rev = "72afa31" }
+trilink-core = { git = "https://github.com/edgesentry/trilink-core.git", rev = "b8dada7ee696315d0b93f462c9ff27f001483dfd" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
## Summary

After #412, `trilink-core` was pinned to interim commit `72afa31`. This updates to **main HEAD** `b8dada7ee696315d0b93f462c9ff27f001483dfd` (includes [trilink-core#93](https://github.com/edgesentry/trilink-core/pull/93) glam 0.33 on main).

**Pin style:** `rev = "<40-char git commit SHA>"` — Cargo’s immutable git dependency pin. There is no SHA-256 field; use `git rev-parse HEAD` on trilink-core when bumping.

## Test plan

- [x] `cargo clippy -p edgesentry-inspect --all-targets -- -D warnings`


Made with [Cursor](https://cursor.com)