### PR TITLE
feat(audit): W4 clearance manifest audit seal + verify-chain

### DIFF
--- a/crates/edgesentry-audit/fixtures/clearance/vessel-hold_evaluation_manifest.json
+++ b/crates/edgesentry-audit/fixtures/clearance/vessel-hold_evaluation_manifest.json
@@ -1,0 +1,14 @@
+{
+  "vessel_key": "vessel-hold",
+  "port_call_id": "port-call-demo-sgsin",
+  "rule_pack_id": "sg-cyber-clearance-v0",
+  "rule_pack_version": "0.1.0",
+  "rule_pack_sha256": "0000000000000000000000000000000000000000000000000000000000000001",
+  "cve_snapshot_sha256": "0000000000000000000000000000000000000000000000000000000000000002",
+  "sbom_sha256": "0000000000000000000000000000000000000000000000000000000000000003",
+  "outcome": "hold",
+  "rules_fired": ["SG-CC-001", "SG-CC-002", "SG-CC-007"],
+  "graph_node_count": 6,
+  "graph_edge_count": 5,
+  "decision_hash": "cf645aac3a633b4308b9ca3c267ab811c66f1a2563cd04f02daca08b2b1ec867"
+}

--- a/crates/edgesentry-audit/src/clearance.rs
+++ b/crates/edgesentry-audit/src/clearance.rs
@@ -1,0 +1,105 @@
+//! Port Cyber Clearance evaluation manifest sealing (Cap Vista W4).
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::CliError;
+
+/// Payload sealed into the audit chain for an indago clearance evaluation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClearanceAuditPayload {
+    pub record_type: String,
+    pub manifest: ClearanceManifestBody,
+}
+
+/// Manifest fields hashed by indago `decision_hash` (excludes `decision_hash` itself).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClearanceManifestBody {
+    pub vessel_key: String,
+    pub port_call_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule_pack_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule_pack_version: Option<String>,
+    pub rule_pack_sha256: String,
+    pub cve_snapshot_sha256: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sbom_sha256: Option<String>,
+    pub outcome: String,
+    pub rules_fired: Vec<String>,
+    pub graph_node_count: u64,
+    pub graph_edge_count: u64,
+}
+
+/// Parse evaluation manifest JSON (with optional `decision_hash` field stripped for signing).
+pub fn parse_clearance_manifest_json(content: &str) -> Result<ClearanceManifestBody, CliError> {
+    let value: Value = serde_json::from_str(content)?;
+    manifest_body_from_value(value)
+}
+
+pub fn manifest_body_from_value(mut value: Value) -> Result<ClearanceManifestBody, CliError> {
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("decision_hash");
+    }
+    serde_json::from_value(value).map_err(Into::into)
+}
+
+/// Canonical JSON bytes for signing (matches indago `decision_hash` input + record_type wrapper).
+pub fn build_clearance_payload_bytes(manifest: &ClearanceManifestBody) -> Result<Vec<u8>, CliError> {
+    let payload = ClearanceAuditPayload {
+        record_type: "port_cyber_clearance".to_string(),
+        manifest: manifest.clone(),
+    };
+    let value = serde_json::to_value(&payload)?;
+    let canonical = canonicalize_json(value);
+    serde_json::to_vec(&canonical).map_err(Into::into)
+}
+
+pub fn payload_hash_hex(payload_bytes: &[u8]) -> String {
+    hex::encode(blake3::hash(payload_bytes).as_bytes())
+}
+
+fn canonicalize_json(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let sorted: BTreeMap<String, Value> = map
+                .into_iter()
+                .map(|(k, v)| (k, canonicalize_json(v)))
+                .collect();
+            let mut map = serde_json::Map::new();
+            for (k, v) in sorted {
+                map.insert(k, v);
+            }
+            Value::Object(map)
+        }
+        Value::Array(items) => Value::Array(items.into_iter().map(canonicalize_json).collect()),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_payload_is_stable() {
+        let manifest = ClearanceManifestBody {
+            vessel_key: "vessel-hold".into(),
+            port_call_id: "pc-1".into(),
+            rule_pack_id: Some("sg-cyber-clearance-v0".into()),
+            rule_pack_version: Some("0.1.0".into()),
+            rule_pack_sha256: "aa".repeat(64),
+            cve_snapshot_sha256: "bb".repeat(64),
+            sbom_sha256: Some("cc".repeat(64)),
+            outcome: "hold".into(),
+            rules_fired: vec!["SG-CC-001".into()],
+            graph_node_count: 6,
+            graph_edge_count: 5,
+        };
+        let a = build_clearance_payload_bytes(&manifest).unwrap();
+        let b = build_clearance_payload_bytes(&manifest).unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/crates/edgesentry-audit/src/lib.rs
+++ b/crates/edgesentry-audit/src/lib.rs
@@ -1,4 +1,5 @@
 mod agent;
+pub mod clearance;
 pub mod buffer;
 pub mod identity;
 pub mod integrity;
@@ -28,6 +29,10 @@ pub use ingest::{PostgresAuditLedger, PostgresOperationLog, PostgresStoreError};
 pub use ingest::{
     AsyncAuditLedger, AsyncInMemoryAuditLedger, AsyncInMemoryOperationLog,
     AsyncInMemoryRawDataStore, AsyncIngestService, AsyncOperationLogStore, AsyncRawDataStore,
+};
+pub use clearance::{
+    build_clearance_payload_bytes, manifest_body_from_value, parse_clearance_manifest_json,
+    payload_hash_hex, ClearanceAuditPayload, ClearanceManifestBody,
 };
 pub use record::{AuditRecord, Hash32, Signature64};
 

--- a/crates/edgesentry-audit/tests/unit.rs
+++ b/crates/edgesentry-audit/tests/unit.rs
@@ -1,3 +1,5 @@
+#[path = "unit/clearance_tests.rs"]
+mod clearance_tests;
 #[path = "unit/core_tests.rs"]
 mod core_tests;
 #[path = "unit/network_policy_tests.rs"]

--- a/crates/edgesentry-audit/tests/unit/clearance_tests.rs
+++ b/crates/edgesentry-audit/tests/unit/clearance_tests.rs
@@ -1,0 +1,35 @@
+use edgesentry_audit::{
+    build_clearance_payload_bytes, inspect_key, parse_clearance_manifest_json, sign_record,
+    verify_chain_records, verify_record, AuditRecord,
+};
+
+const PRIV_HEX: &str = "0101010101010101010101010101010101010101010101010101010101010101";
+
+#[test]
+fn clearance_manifest_strips_decision_hash_for_payload() {
+    let raw = include_str!("../../fixtures/clearance/vessel-hold_evaluation_manifest.json");
+    let body = parse_clearance_manifest_json(raw).expect("parse");
+    assert_eq!(body.vessel_key, "vessel-hold");
+    assert_eq!(body.outcome, "hold");
+}
+
+#[test]
+fn clearance_sign_and_verify_chain() {
+    let raw = include_str!("../../fixtures/clearance/vessel-hold_evaluation_manifest.json");
+    let body = parse_clearance_manifest_json(raw).expect("parse");
+    let payload = build_clearance_payload_bytes(&body).expect("payload");
+    let record = sign_record(
+        "port-clearance-poc".into(),
+        1,
+        1_700_000_000_000,
+        payload,
+        AuditRecord::zero_hash(),
+        "clearance:vessel-hold/port-call-demo-sgsin".into(),
+        PRIV_HEX,
+    )
+    .expect("sign");
+    let records = vec![record];
+    verify_chain_records(&records).expect("chain");
+    let pub_hex = inspect_key(PRIV_HEX).expect("inspect").public_key_hex;
+    assert!(verify_record(&records[0], &pub_hex).expect("verify sig"));
+}

--- a/crates/eds/src/audit.rs
+++ b/crates/eds/src/audit.rs
@@ -4,9 +4,10 @@ use std::path::PathBuf;
 
 use clap::Subcommand;
 use edgesentry_audit::{
-    build_lift_inspection_demo_records_with_payloads, generate_keypair, inspect_key,
-    parse_fixed_hex, sign_record, verify_chain_file, verify_chain_records, verify_record,
-    write_record_json, write_records_json, AuditRecord,
+    build_clearance_payload_bytes, build_lift_inspection_demo_records_with_payloads,
+    generate_keypair, inspect_key, parse_clearance_manifest_json, parse_fixed_hex, sign_record,
+    verify_chain_file, verify_chain_records, verify_record, write_record_json, write_records_json,
+    AuditRecord,
 };
 use edgesentry_document::{build_audit_payload, FilledDocument};
 use edgesentry_evaluate::RiskEvent;
@@ -177,6 +178,31 @@ pub enum AuditCommand {
         #[arg(long)]
         payload: PathBuf,
         /// AuditRecord JSON array to search (output of sign-document).
+        #[arg(long)]
+        chain: PathBuf,
+    },
+    /// Sign an indago port cyber clearance evaluation manifest.
+    ///
+    /// Reads `*_evaluation_manifest.json` from `port_clearance_eval`, seals a
+    /// canonical `ClearanceAuditPayload`, and appends an `AuditRecord` to the chain.
+    SignClearance {
+        /// Evaluation manifest JSON (indago `write_evaluation_artifacts` output).
+        #[arg(long)]
+        manifest: PathBuf,
+        /// Ed25519 private key hex (32 bytes).
+        #[arg(long)]
+        key: String,
+        #[arg(long, default_value = "port-clearance")]
+        device_id: String,
+        #[arg(long)]
+        chain: Option<PathBuf>,
+        #[arg(long)]
+        out: PathBuf,
+    },
+    /// Verify a clearance manifest matches its AuditRecord and validate the chain.
+    VerifyClearance {
+        #[arg(long)]
+        manifest: PathBuf,
         #[arg(long)]
         chain: PathBuf,
     },
@@ -592,6 +618,85 @@ pub fn run(cmd: AuditCommand) -> Result<(), Box<dyn std::error::Error>> {
 
             write_records_json(&out, &records)?;
             println!("SIGNED: {} document record(s) written to {}", records.len(), out.display());
+        }
+
+        AuditCommand::SignClearance { manifest, key, device_id, chain, out } => {
+            let manifest_body = parse_clearance_manifest_json(&std::fs::read_to_string(&manifest)?)?;
+            let payload_bytes = build_clearance_payload_bytes(&manifest_body)?;
+            let object_ref = format!(
+                "clearance:{}/{}",
+                manifest_body.vessel_key, manifest_body.port_call_id
+            );
+
+            let (sequence, prev_hash, prior_records) = if let Some(ref chain_path) = chain {
+                let existing: Vec<AuditRecord> =
+                    serde_json::from_str(&std::fs::read_to_string(chain_path)?)?;
+                let seq = existing.last().map(|r| r.sequence + 1).unwrap_or(1);
+                let ph = existing.last().map(|r| r.hash()).unwrap_or(AuditRecord::zero_hash());
+                (seq, ph, existing)
+            } else {
+                (1u64, AuditRecord::zero_hash(), Vec::new())
+            };
+
+            let timestamp_ms = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_millis() as u64)
+                .unwrap_or(0);
+
+            let record = sign_record(
+                device_id,
+                sequence,
+                timestamp_ms,
+                payload_bytes,
+                prev_hash,
+                object_ref,
+                &key,
+            )?;
+
+            let mut records = prior_records;
+            records.push(record);
+            verify_chain_records(&records)?;
+            write_records_json(&out, &records)?;
+            println!(
+                "SIGNED: clearance {} → {} ({} record(s))",
+                manifest_body.vessel_key,
+                manifest_body.outcome,
+                records.len()
+            );
+        }
+
+        AuditCommand::VerifyClearance { manifest, chain } => {
+            let manifest_content = std::fs::read_to_string(&manifest)?;
+            let manifest_body = parse_clearance_manifest_json(&manifest_content)?;
+            let payload_bytes = build_clearance_payload_bytes(&manifest_body)?;
+            let payload_hash = *blake3::hash(&payload_bytes).as_bytes();
+
+            let records: Vec<AuditRecord> =
+                serde_json::from_str(&std::fs::read_to_string(&chain)?)?;
+            verify_chain_records(&records)?;
+
+            let matched = records.iter().find(|r| r.payload_hash == payload_hash);
+            match matched {
+                Some(record) => {
+                    println!("VERIFIED");
+                    println!("  vessel_key:    {}", manifest_body.vessel_key);
+                    println!("  port_call_id:  {}", manifest_body.port_call_id);
+                    println!("  outcome:       {}", manifest_body.outcome);
+                    println!("  rules_fired:   {}", manifest_body.rules_fired.join(", "));
+                    println!("  sequence:      {}", record.sequence);
+                    println!("  device_id:     {}", record.device_id);
+                    if let Ok(full) = serde_json::from_str::<serde_json::Value>(&manifest_content) {
+                        if let Some(dh) = full.get("decision_hash").and_then(|v| v.as_str()) {
+                            println!("  decision_hash: {dh}");
+                        }
+                    }
+                    println!("CHAIN_VALID");
+                }
+                None => {
+                    eprintln!("NOT_FOUND: no AuditRecord matches this clearance manifest");
+                    std::process::exit(2);
+                }
+            }
         }
 
             AuditCommand::ExportAims { chain, events, profile_dir, out, md } => {

--- a/crates/eds/tests/cli_integration.rs
+++ b/crates/eds/tests/cli_integration.rs
@@ -1205,3 +1205,90 @@ fn sign_clearance_verify_chain_and_manifest() {
     assert!(vout.contains("vessel-hold"));
     assert!(vout.contains("hold"));
 }
+
+fn indago_repo_root() -> Option<PathBuf> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../../indago");
+    let eval = root.join("pipelines/maritime_cyber/eval.py");
+    if eval.is_file() {
+        Some(root)
+    } else {
+        None
+    }
+}
+
+/// Generate a manifest via indago `evaluate_port_clearance`, then sign with eds (W4 smoke).
+#[test]
+fn sign_clearance_with_indago_generated_manifest() {
+    let indago = match indago_repo_root() {
+        Some(p) => p,
+        None => {
+            eprintln!("skip: sibling indago repo not found");
+            return;
+        }
+    };
+
+    let out_dir = TmpFile::new("indago_eval_out");
+    fs::create_dir_all(out_dir.path()).expect("mkdir");
+
+    let py = format!(
+        r#"
+import json
+from pathlib import Path
+from pipelines.maritime_cyber.eval import evaluate_port_clearance, write_evaluation_artifacts
+from pipelines.maritime_cyber.graph import build_maritime_cyber_graph
+
+g = build_maritime_cyber_graph(["vessel-hold"])
+r = evaluate_port_clearance("vessel-hold", graph_result=g)
+paths = write_evaluation_artifacts(r, Path("{}"))
+print(json.dumps({{"manifest": str(paths["manifest"])}}))
+"#,
+        out_dir.path().display()
+    );
+
+    let gen = Command::new("uv")
+        .args(["run", "python", "-c", &py])
+        .current_dir(&indago)
+        .output()
+        .expect("uv run indago eval");
+
+    if !gen.status.success() {
+        let uv = Command::new("python3")
+            .args(["-c", &py])
+            .current_dir(&indago)
+            .env("PYTHONPATH", indago.to_str().unwrap())
+            .output()
+            .expect("python indago eval");
+        assert!(uv.status.success(), "indago eval failed:\n{}\n{}", stderr(&uv), stdout(&uv));
+        let meta: serde_json::Value = serde_json::from_str(stdout(&uv).trim()).expect("json");
+        let manifest = PathBuf::from(meta["manifest"].as_str().expect("manifest path"));
+        run_sign_verify_clearance(&manifest);
+        return;
+    }
+
+    let meta: serde_json::Value = serde_json::from_str(stdout(&gen).trim()).expect("json");
+    let manifest = PathBuf::from(meta["manifest"].as_str().expect("manifest path"));
+    run_sign_verify_clearance(&manifest);
+}
+
+fn run_sign_verify_clearance(manifest_path: &PathBuf) {
+    assert!(manifest_path.exists(), "manifest missing: {}", manifest_path.display());
+    let chain = TmpFile::new("indago_clearance_chain.json");
+    let sign = eds()
+        .args(["audit", "sign-clearance", "--manifest"])
+        .arg(manifest_path)
+        .args(["--key", PRIV_HEX, "--device-id", "port-clearance-poc", "--out"])
+        .arg(chain.path())
+        .output()
+        .expect("sign-clearance");
+    assert!(sign.status.success(), "sign-clearance: {}", stderr(&sign));
+
+    let verify = eds()
+        .args(["audit", "verify-clearance", "--manifest"])
+        .arg(manifest_path)
+        .args(["--chain"])
+        .arg(chain.path())
+        .output()
+        .expect("verify-clearance");
+    assert!(verify.status.success(), "verify-clearance: {}", stderr(&verify));
+    assert!(stdout(&verify).contains("VERIFIED"));
+}

--- a/crates/eds/tests/cli_integration.rs
+++ b/crates/eds/tests/cli_integration.rs
@@ -1153,3 +1153,55 @@ fn export_aims_exits_zero_and_writes_json_bundle() {
     assert!(md_content.contains("A.4.6"), "markdown must have A.4.6 section");
     assert!(md_content.contains("Disclaimer"), "markdown must include disclaimer");
 }
+
+// ── port cyber clearance (W4) ─────────────────────────────────────────────────
+
+fn clearance_manifest_fixture() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../edgesentry-audit/fixtures/clearance/vessel-hold_evaluation_manifest.json")
+}
+
+#[test]
+fn sign_clearance_verify_chain_and_manifest() {
+    let manifest_path = clearance_manifest_fixture();
+    assert!(manifest_path.exists(), "fixture missing: {}", manifest_path.display());
+
+    let chain = TmpFile::new("clearance_chain.json");
+    let sign = eds()
+        .args([
+            "audit",
+            "sign-clearance",
+            "--manifest",
+        ])
+        .arg(&manifest_path)
+        .args(["--key", PRIV_HEX, "--device-id", "port-clearance-poc", "--out"])
+        .arg(chain.path())
+        .output()
+        .expect("sign-clearance");
+    assert!(sign.status.success(), "sign-clearance: {}", stderr(&sign));
+
+    let chain_check = eds()
+        .args(["audit", "verify-chain", "--records-file"])
+        .arg(chain.path())
+        .output()
+        .expect("verify-chain");
+    assert!(chain_check.status.success(), "verify-chain: {}", stderr(&chain_check));
+    assert!(stdout(&chain_check).contains("CHAIN_VALID"));
+
+    let verify = eds()
+        .args([
+            "audit",
+            "verify-clearance",
+            "--manifest",
+        ])
+        .arg(&manifest_path)
+        .args(["--chain"])
+        .arg(chain.path())
+        .output()
+        .expect("verify-clearance");
+    assert!(verify.status.success(), "verify-clearance: {}", stderr(&verify));
+    let vout = stdout(&verify);
+    assert!(vout.contains("VERIFIED"));
+    assert!(vout.contains("vessel-hold"));
+    assert!(vout.contains("hold"));
+}

--- a/docs/port-cyber-clearance-audit.md
+++ b/docs/port-cyber-clearance-audit.md
@@ -1,0 +1,62 @@
+# Port Cyber Clearance — audit seal and third-party verify
+
+Cap Vista PoC (W4): seal indago clearance evaluation manifests with `edgesentry-rs` `AuditRecord` chains.
+
+## Prerequisites
+
+- `eds` binary: `cargo build --release -p eds`
+- indago evaluation output: `*_evaluation_manifest.json` from `port_clearance_eval.py evaluate --write`
+
+## 1. Generate a keypair (once per demo environment)
+
+```bash
+eds audit keygen > /tmp/clearance-keypair.json
+KEY=$(python3 -c "import json; print(json.load(open('/tmp/clearance-keypair.json'))['private_key_hex'])")
+```
+
+## 2. Sign the evaluation manifest
+
+```bash
+eds audit sign-clearance \
+  --manifest data/processed/maritime_cyber/vessel-hold_port-call-demo-sgsin_evaluation_manifest.json \
+  --key "$KEY" \
+  --device-id port-clearance-poc \
+  --out /tmp/clearance-chain.json
+```
+
+## 3. Third-party verify (no EdgeSentry UI)
+
+### Chain integrity
+
+```bash
+eds audit verify-chain --records-file /tmp/clearance-chain.json
+# CHAIN_VALID
+```
+
+### Manifest matches sealed payload
+
+```bash
+eds audit verify-clearance \
+  --manifest data/processed/maritime_cyber/vessel-hold_port-call-demo-sgsin_evaluation_manifest.json \
+  --chain /tmp/clearance-chain.json
+# VERIFIED + CHAIN_VALID
+```
+
+If the manifest or chain was tampered with after signing, `verify-clearance` exits non-zero.
+
+## End-to-end with indago (demo script)
+
+```bash
+# indago repo
+uv run python pipelines/port_clearance_eval.py evaluate vessel-hold --write
+
+# edgesentry-rs repo
+cargo build --release -p eds
+eds audit sign-clearance --manifest .../vessel-hold_port-call-demo-sgsin_evaluation_manifest.json ...
+eds audit verify-chain --records-file /tmp/clearance-chain.json
+eds audit verify-clearance --manifest ... --chain /tmp/clearance-chain.json
+```
+
+## Honesty (portal)
+
+PoC uses **public CVE** + **synthetic SBOM/asset_map** fixtures. The audit chain proves **what was evaluated and when** — not MPA official berth approval.


### PR DESCRIPTION
## Achievement — W4 / #414

| #414 task | Status | Implementation |
|-----------|--------|----------------|
| `AuditRecord` on evaluation manifest | Done | `eds audit sign-clearance` → `ClearanceAuditPayload` sealed in chain |
| `eds audit verify-chain` in CI | Done | `sign_clearance_verify_chain_and_manifest` CLI integration test |
| Third-party verify docs | Done | [docs/port-cyber-clearance-audit.md](docs/port-cyber-clearance-audit.md) |

**MVP gates:** G6 (audit seal), G7 (manifest hash aligns with indago `decision_hash` input).

## Summary

- **`edgesentry_audit::clearance`** — canonical payload from indago `*_evaluation_manifest.json`
- **`eds audit sign-clearance`** — sign manifest → `AuditRecord` JSON array
- **`eds audit verify-clearance`** — manifest ↔ chain match + `CHAIN_VALID`
- **Fixture:** `crates/edgesentry-audit/fixtures/clearance/vessel-hold_evaluation_manifest.json`

## Related

- Refs #414 — close on merge
- indago W3 (#186) produces manifests to sign
- Enables W6 E2E orchestration

## Test plan

- [x] `cargo test -p edgesentry-audit clearance`
- [x] `cargo test -p eds --test cli_integration sign_clearance`

Made with [Cursor](https://cursor.com)