### PR TITLE
feat(document): port-cyber-clearance template from indago facts (W5)

### DIFF
--- a/crates/edgesentry-document/fixtures/clearance/vessel-clean_facts.json
+++ b/crates/edgesentry-document/fixtures/clearance/vessel-clean_facts.json
@@ -1,0 +1,10 @@
+{
+  "vessel_key": "vessel-clean",
+  "port_call_id": "port-call-demo-sgsin",
+  "outcome": "pass",
+  "decision_hash": "23f3c166a82b4d614ebccea7b26ec1aeaaa96bb854b487fbc37093cf4de31889",
+  "rules_fired": [],
+  "paths": [],
+  "cve_ids": [],
+  "disclaimer": "PoC clearance from public CVE snapshot and synthetic SBOM/asset_map fixtures. Not an official port-state or MPA berth approval."
+}

--- a/crates/edgesentry-document/fixtures/clearance/vessel-hold_facts.json
+++ b/crates/edgesentry-document/fixtures/clearance/vessel-hold_facts.json
@@ -1,0 +1,83 @@
+{
+  "vessel_key": "vessel-hold",
+  "port_call_id": "port-call-demo-sgsin",
+  "outcome": "hold",
+  "decision_hash": "cf645aac3a633b4308b9ca3c267ab811c66f1a2563cd04f02daca08b2b1ec867",
+  "rules_fired": [
+    {
+      "id": "SG-CC-001",
+      "title": "Critical CVE on safety-related CBS",
+      "severity": "critical",
+      "requirements": [
+        "IACS-E26-1",
+        "IACS-E27-2",
+        "IMO-428-5"
+      ],
+      "evidence": {
+        "path": [
+          "asset:vessel-hold:ecdis-01",
+          "firmware:vessel-hold:ecdis-fw-2023.4",
+          "component:vessel-hold:27620e88ddac",
+          "cve:CVE-2021-44228"
+        ],
+        "cve_id": "cve:CVE-2021-44228",
+        "cvss_score": 10.0,
+        "cbs_category": "navigation"
+      }
+    },
+    {
+      "id": "SG-CC-002",
+      "title": "High CVE on navigation or ECDIS software path",
+      "severity": "high",
+      "requirements": [
+        "IACS-E26-1",
+        "IACS-E27-2",
+        "IMO-428-5"
+      ],
+      "evidence": {
+        "path": [
+          "asset:vessel-hold:ecdis-01",
+          "firmware:vessel-hold:ecdis-fw-2023.4",
+          "component:vessel-hold:27620e88ddac",
+          "cve:CVE-2021-44228"
+        ],
+        "cve_id": "cve:CVE-2021-44228",
+        "cvss_score": 10.0,
+        "cbs_category": "navigation"
+      }
+    },
+    {
+      "id": "SG-CC-007",
+      "title": "Known exploited vulnerability present on vessel SBOM path",
+      "severity": "critical",
+      "requirements": [
+        "IMO-428-5",
+        "OSV-1"
+      ],
+      "evidence": {
+        "cve_id": "cve:CVE-2021-44228",
+        "in_kev": true
+      }
+    }
+  ],
+  "paths": [
+    {
+      "rule_ids": [
+        "SG-CC-001",
+        "SG-CC-002",
+        "SG-CC-007"
+      ],
+      "nodes": [
+        "asset:vessel-hold:ecdis-01",
+        "firmware:vessel-hold:ecdis-fw-2023.4",
+        "component:vessel-hold:27620e88ddac",
+        "cve:CVE-2021-44228"
+      ],
+      "summary": "None \u2192 GHSA-jfhr-c2vg-8q4j (CVSS 10.0)"
+    }
+  ],
+  "cve_ids": [
+    "cve:CVE-2021-44228"
+  ],
+  "disclaimer": "PoC clearance from public CVE snapshot and synthetic SBOM/asset_map fixtures. Not an official port-state or MPA berth approval."
+}

--- a/crates/edgesentry-document/src/clearance.rs
+++ b/crates/edgesentry-document/src/clearance.rs
@@ -1,0 +1,207 @@
+//! Port Cyber Clearance certificate — fill from indago `*_facts.json` (Cap Vista W5).
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use crate::{FieldSource, FieldValue, FilledDocument};
+
+/// indago `write_evaluation_artifacts` facts payload.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct ClearanceFacts {
+    pub vessel_key: String,
+    pub port_call_id: String,
+    pub outcome: String,
+    pub decision_hash: String,
+    #[serde(default)]
+    pub rules_fired: Vec<ClearanceRuleHit>,
+    #[serde(default)]
+    pub paths: Vec<ClearancePath>,
+    #[serde(default)]
+    pub cve_ids: Vec<String>,
+    pub disclaimer: String,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct ClearanceRuleHit {
+    pub id: String,
+    pub title: String,
+    pub severity: String,
+    #[serde(default)]
+    pub requirements: Vec<String>,
+    #[serde(default)]
+    pub evidence: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct ClearancePath {
+    #[serde(default)]
+    pub rule_ids: Vec<String>,
+    #[serde(default)]
+    pub nodes: Vec<String>,
+    pub summary: String,
+}
+
+pub const TEMPLATE_ID: &str = "port-cyber-clearance";
+
+pub const TEMPLATE_HTML: &str = include_str!("../templates/port-cyber-clearance.html");
+
+fn direct(value: impl Into<String>) -> FieldValue {
+    FieldValue {
+        value: value.into(),
+        confidence: 1.0,
+        source: FieldSource::Direct,
+        flagged: false,
+    }
+}
+
+fn escape_html(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+fn rules_table_rows(rules: &[ClearanceRuleHit]) -> String {
+    if rules.is_empty() {
+        return "<tr><td colspan=\"4\" class=\"muted\">No rules fired — clearance pass</td></tr>".to_string();
+    }
+    rules
+        .iter()
+        .map(|r| {
+            format!(
+                "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+                escape_html(&r.id),
+                escape_html(&r.title),
+                escape_html(&r.severity),
+                escape_html(&r.requirements.join(", ")),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn paths_table_rows(paths: &[ClearancePath]) -> String {
+    if paths.is_empty() {
+        return "<tr><td colspan=\"3\" class=\"muted\">No cited vulnerability paths</td></tr>".to_string();
+    }
+    paths
+        .iter()
+        .map(|p| {
+            format!(
+                "<tr><td>{}</td><td>{}</td><td>{}</td></tr>",
+                escape_html(&p.rule_ids.join(", ")),
+                escape_html(&p.summary),
+                escape_html(&p.nodes.join(" → ")),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn summary_paragraph(facts: &ClearanceFacts) -> String {
+    let outcome_upper = facts.outcome.to_uppercase();
+    if facts.outcome == "hold" {
+        format!(
+            "Vessel <strong>{}</strong> on port call <strong>{}</strong> received clearance outcome \
+             <strong>{outcome_upper}</strong>. {} rule(s) fired across {} cited path(s). \
+             Berth recommendation: review cyber exposure before port entry.",
+            escape_html(&facts.vessel_key),
+            escape_html(&facts.port_call_id),
+            facts.rules_fired.len(),
+            facts.paths.len(),
+        )
+    } else {
+        format!(
+            "Vessel <strong>{}</strong> on port call <strong>{}</strong> received clearance outcome \
+             <strong>{outcome_upper}</strong>. No blocking rules fired on the pinned CVE snapshot and SBOM fixtures.",
+            escape_html(&facts.vessel_key),
+            escape_html(&facts.port_call_id),
+        )
+    }
+}
+
+/// Map indago facts + verify URL into a `FilledDocument` for `port-cyber-clearance.html`.
+pub fn fill_clearance(facts: &ClearanceFacts, verify_url: &str) -> FilledDocument {
+    let outcome_upper = facts.outcome.to_uppercase();
+    let outcome_class = if facts.outcome == "hold" {
+        "outcome-hold"
+    } else {
+        "outcome-pass"
+    };
+    let cve_line = if facts.cve_ids.is_empty() {
+        "None identified on evaluation paths".to_string()
+    } else {
+        facts.cve_ids.join(", ")
+    };
+    let generated_date = "2026-05-27";
+
+    let mut fields: HashMap<String, FieldValue> = HashMap::new();
+    fields.insert("VESSEL_KEY".to_string(), direct(&facts.vessel_key));
+    fields.insert("PORT_CALL_ID".to_string(), direct(&facts.port_call_id));
+    fields.insert("OUTCOME".to_string(), direct(outcome_upper));
+    fields.insert("OUTCOME_CLASS".to_string(), direct(outcome_class));
+    fields.insert("DECISION_HASH".to_string(), direct(&facts.decision_hash));
+    fields.insert("GENERATED_DATE".to_string(), direct(generated_date));
+    fields.insert("VERIFY_URL".to_string(), direct(verify_url));
+    fields.insert("CVE_IDS".to_string(), direct(cve_line));
+    fields.insert("DISCLAIMER".to_string(), direct(&facts.disclaimer));
+    fields.insert("SUMMARY_HTML".to_string(), direct(summary_paragraph(facts)));
+    fields.insert("RULES_TABLE_ROWS".to_string(), direct(rules_table_rows(&facts.rules_fired)));
+    fields.insert("PATHS_TABLE_ROWS".to_string(), direct(paths_table_rows(&facts.paths)));
+    fields.insert(
+        "RULES_COUNT".to_string(),
+        direct(facts.rules_fired.len().to_string()),
+    );
+
+    let voyage_id = format!("{}_{}", facts.vessel_key, facts.port_call_id);
+
+    FilledDocument {
+        voyage_id,
+        template: TEMPLATE_ID.to_string(),
+        fields,
+        review_required: facts.outcome == "hold",
+    }
+}
+
+pub fn parse_clearance_facts_json(content: &str) -> Result<ClearanceFacts, String> {
+    serde_json::from_str(content).map_err(|e| format!("facts JSON parse error: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render_html;
+
+    const HOLD_FACTS: &str = include_str!("../fixtures/clearance/vessel-hold_facts.json");
+    const CLEAN_FACTS: &str = include_str!("../fixtures/clearance/vessel-clean_facts.json");
+
+    #[test]
+    fn fill_clearance_hold_marks_review_required() {
+        let facts = parse_clearance_facts_json(HOLD_FACTS).unwrap();
+        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo");
+        assert!(doc.review_required);
+        assert_eq!(doc.template, TEMPLATE_ID);
+        assert_eq!(doc.fields.get("OUTCOME").unwrap().value, "HOLD");
+    }
+
+    #[test]
+    fn fill_clearance_pass_no_review() {
+        let facts = parse_clearance_facts_json(CLEAN_FACTS).unwrap();
+        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo");
+        assert!(!doc.review_required);
+        assert_eq!(doc.fields.get("OUTCOME").unwrap().value, "PASS");
+    }
+
+    #[test]
+    fn render_clearance_html_contains_outcome_and_verify() {
+        let facts = parse_clearance_facts_json(HOLD_FACTS).unwrap();
+        let doc = fill_clearance(&facts, "https://verify.example/clearance/abc123");
+        let html = render_html(&doc, TEMPLATE_HTML);
+        assert!(html.contains("HOLD"));
+        assert!(html.contains("vessel-hold"));
+        assert!(html.contains("https://verify.example/clearance/abc123"));
+        assert!(html.contains("SG-CC-001"));
+        assert!(!html.contains("{{OUTCOME}}"));
+    }
+}

--- a/crates/edgesentry-document/src/lib.rs
+++ b/crates/edgesentry-document/src/lib.rs
@@ -3,6 +3,13 @@ use std::collections::HashMap;
 use edgesentry_parse::DocumentEntity;
 use serde::{Deserialize, Serialize};
 
+pub mod clearance;
+
+pub use clearance::{
+    fill_clearance, parse_clearance_facts_json, ClearanceFacts, ClearancePath, ClearanceRuleHit,
+    TEMPLATE_HTML as PORT_CYBER_CLEARANCE_HTML, TEMPLATE_ID as PORT_CYBER_CLEARANCE_TEMPLATE,
+};
+
 /// Payload sealed into the audit chain for a generated compliance document.
 ///
 /// Constructed from a [`FilledDocument`] immediately before signing.

--- a/crates/edgesentry-document/templates/port-cyber-clearance.html
+++ b/crates/edgesentry-document/templates/port-cyber-clearance.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Port Cyber Clearance — {{VESSEL_KEY}}</title>
+<style>
+  @page { size: A4; margin: 18mm; }
+  body { font-family: "Helvetica Neue", Arial, sans-serif; font-size: 11px; color: #0f172a; margin: 0; line-height: 1.45; }
+  .header-band {
+    background: linear-gradient(135deg, #0c2340 0%, #1e4a7a 100%);
+    color: #fff;
+    padding: 16px 20px;
+    margin-bottom: 12px;
+  }
+  .header-band h1 { margin: 0; font-size: 16px; letter-spacing: 0.04em; font-weight: 700; }
+  .header-band .sub { font-size: 10px; opacity: 0.9; margin-top: 6px; }
+  .meta-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px 24px;
+    margin-bottom: 16px;
+    padding: 12px 16px;
+    background: #f1f5f9;
+    border: 1px solid #cbd5e1;
+  }
+  .meta-grid dt { font-size: 9px; text-transform: uppercase; color: #64748b; margin: 0 0 2px; }
+  .meta-grid dd { margin: 0; font-weight: 600; font-size: 11px; }
+  .outcome-badge {
+    display: inline-block;
+    padding: 6px 14px;
+    border-radius: 4px;
+    font-weight: 700;
+    font-size: 13px;
+    letter-spacing: 0.06em;
+  }
+  .outcome-hold { background: #fef2f2; color: #b91c1c; border: 2px solid #dc2626; }
+  .outcome-pass { background: #ecfdf5; color: #047857; border: 2px solid #10b981; }
+  .section-title {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #1e4a7a;
+    border-bottom: 2px solid #1e4a7a;
+    padding-bottom: 4px;
+    margin: 18px 0 8px;
+  }
+  .summary { margin-bottom: 12px; }
+  table { width: 100%; border-collapse: collapse; margin-bottom: 12px; font-size: 10px; }
+  th, td { border: 1px solid #cbd5e1; padding: 6px 8px; text-align: left; vertical-align: top; }
+  th { background: #e2e8f0; font-weight: 600; }
+  .muted { color: #64748b; font-style: italic; }
+  .hash-box {
+    font-family: ui-monospace, monospace;
+    font-size: 9px;
+    word-break: break-all;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    padding: 8px 10px;
+    margin: 8px 0;
+  }
+  .verify-box {
+    background: #eff6ff;
+    border: 1px solid #93c5fd;
+    padding: 10px 12px;
+    margin: 12px 0;
+    font-size: 10px;
+  }
+  .verify-box a { color: #1d4ed8; word-break: break-all; }
+  .disclaimer {
+    margin-top: 20px;
+    padding-top: 10px;
+    border-top: 1px solid #cbd5e1;
+    font-size: 9px;
+    color: #64748b;
+  }
+  .footer { font-size: 8px; color: #94a3b8; margin-top: 8px; }
+</style>
+</head>
+<body>
+
+<div class="header-band">
+  <h1>EDGESENTRY PORT CYBER CLEARANCE</h1>
+  <div class="sub">Deterministic SBOM × CVE × rules evaluation · Cap Vista PoC · Generated {{GENERATED_DATE}}</div>
+</div>
+
+<div class="meta-grid">
+  <div><dt>Vessel</dt><dd>{{VESSEL_KEY}}</dd></div>
+  <div><dt>Port call</dt><dd>{{PORT_CALL_ID}}</dd></div>
+  <div><dt>Rules fired</dt><dd>{{RULES_COUNT}}</dd></div>
+  <div><dt>CVE IDs (paths)</dt><dd>{{CVE_IDS}}</dd></div>
+</div>
+
+<p><span class="outcome-badge {{OUTCOME_CLASS}}">{{OUTCOME}}</span></p>
+
+<div class="section-title">1. Executive summary</div>
+<p class="summary">{{SUMMARY_HTML}}</p>
+
+<div class="section-title">2. Rules fired</div>
+<table>
+  <thead>
+    <tr><th>Rule ID</th><th>Title</th><th>Severity</th><th>Requirements</th></tr>
+  </thead>
+  <tbody>
+    {{RULES_TABLE_ROWS}}
+  </tbody>
+</table>
+
+<div class="section-title">3. Cited vulnerability paths</div>
+<table>
+  <thead>
+    <tr><th>Rules</th><th>Summary</th><th>Graph path</th></tr>
+  </thead>
+  <tbody>
+    {{PATHS_TABLE_ROWS}}
+  </tbody>
+</table>
+
+<div class="section-title">4. Decision integrity</div>
+<p class="muted">Canonical evaluation hash (indago manifest, excludes this field):</p>
+<div class="hash-box">{{DECISION_HASH}}</div>
+
+<div class="section-title">5. Independent verification</div>
+<div class="verify-box">
+  Third parties can verify the signed audit chain and manifest match using <code>eds audit verify-clearance</code>.
+  Portal placeholder (W6): <a href="{{VERIFY_URL}}">{{VERIFY_URL}}</a>
+</div>
+
+<div class="disclaimer">
+  <strong>Disclaimer:</strong> {{DISCLAIMER}}
+</div>
+
+<div class="footer">EdgeSentry · Port Cyber Clearance PoC · Not an official MPA or port-state berth approval</div>
+
+</body>
+</html>

--- a/crates/edgesentry-wasm/src/lib.rs
+++ b/crates/edgesentry-wasm/src/lib.rs
@@ -489,4 +489,45 @@ mod tests {
             "EUI_DATA_PRESENT must fire for B002"
         );
     }
+
+    // ── Port cyber clearance (W5) wasm API tests ─────────────────────────────
+
+    const HOLD_FACTS: &str =
+        include_str!("../../edgesentry-document/fixtures/clearance/vessel-hold_facts.json");
+    const CLEAN_FACTS: &str =
+        include_str!("../../edgesentry-document/fixtures/clearance/vessel-clean_facts.json");
+    const VERIFY_URL: &str = "https://verify.example/clearance/wasm-test";
+
+    #[test]
+    fn wasm_api_fill_clearance_hold() {
+        let filled_json = fill_clearance(HOLD_FACTS, VERIFY_URL).expect("fill_clearance");
+        let filled: serde_json::Value = serde_json::from_str(&filled_json).unwrap();
+        assert!(filled["review_required"].as_bool().unwrap());
+        assert_eq!(filled["template"].as_str().unwrap(), "port-cyber-clearance");
+        assert_eq!(
+            filled["fields"]["OUTCOME"]["value"].as_str().unwrap(),
+            "HOLD"
+        );
+    }
+
+    #[test]
+    fn wasm_api_fill_clearance_pass() {
+        let filled_json = fill_clearance(CLEAN_FACTS, VERIFY_URL).expect("fill_clearance");
+        let filled: serde_json::Value = serde_json::from_str(&filled_json).unwrap();
+        assert!(!filled["review_required"].as_bool().unwrap());
+        assert_eq!(
+            filled["fields"]["OUTCOME"]["value"].as_str().unwrap(),
+            "PASS"
+        );
+    }
+
+    #[test]
+    fn wasm_api_render_clearance_html_hold() {
+        let filled_json = fill_clearance(HOLD_FACTS, VERIFY_URL).expect("fill_clearance");
+        let html = render_html(&filled_json, "port-cyber-clearance").expect("render_html");
+        assert!(html.contains("HOLD"));
+        assert!(html.contains("vessel-hold"));
+        assert!(html.contains(VERIFY_URL));
+        assert!(html.contains("SG-CC-001"));
+    }
 }

--- a/crates/edgesentry-wasm/src/lib.rs
+++ b/crates/edgesentry-wasm/src/lib.rs
@@ -74,6 +74,18 @@ pub fn fill_bca(
     serde_json::to_string(&filled).map_err(|e| JsError::new(&e.to_string()))
 }
 
+/// Fill port cyber clearance certificate from indago `*_facts.json`.
+///
+/// `facts_json`: ClearanceFacts JSON (indago `write_evaluation_artifacts`)
+/// `verify_url`: third-party verification URL printed on the certificate
+#[wasm_bindgen]
+pub fn fill_clearance(facts_json: &str, verify_url: &str) -> Result<String, JsError> {
+    let facts = edgesentry_document::parse_clearance_facts_json(facts_json)
+        .map_err(|e| JsError::new(&e))?;
+    let filled = edgesentry_document::fill_clearance(&facts, verify_url);
+    serde_json::to_string(&filled).map_err(|e| JsError::new(&e.to_string()))
+}
+
 // ── check ─────────────────────────────────────────────────────────────────────
 
 /// Check a FilledDocument against a compliance rules JSON array.
@@ -107,12 +119,13 @@ pub fn render_html(filled_json: &str, template: &str) -> Result<String, JsError>
         serde_json::from_str(filled_json).map_err(|e| JsError::new(&e.to_string()))?;
 
     let template_html = match template {
-        "fal-form-1"       => include_str!("../../edgesentry-document/templates/fal-form-1.html"),
-        "fal-form-5"       => include_str!("../../edgesentry-document/templates/fal-form-5.html"),
-        "sg-port-entry"    => include_str!("../../edgesentry-document/templates/sg-port-entry.html"),
-        "sg-bca-greenmark" => include_str!("../../edgesentry-document/templates/sg-bca-greenmark.html"),
+        "fal-form-1"             => include_str!("../../edgesentry-document/templates/fal-form-1.html"),
+        "fal-form-5"             => include_str!("../../edgesentry-document/templates/fal-form-5.html"),
+        "sg-port-entry"          => include_str!("../../edgesentry-document/templates/sg-port-entry.html"),
+        "sg-bca-greenmark"       => include_str!("../../edgesentry-document/templates/sg-bca-greenmark.html"),
+        "port-cyber-clearance"   => include_str!("../../edgesentry-document/templates/port-cyber-clearance.html"),
         other => return Err(JsError::new(&format!(
-            "unknown template '{other}'; choices: fal-form-1, fal-form-5, sg-port-entry, sg-bca-greenmark"
+            "unknown template '{other}'; choices: fal-form-1, fal-form-5, sg-port-entry, sg-bca-greenmark, port-cyber-clearance"
         ))),
     };
 

--- a/crates/eds/src/document.rs
+++ b/crates/eds/src/document.rs
@@ -2,7 +2,10 @@ use clap::Subcommand;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use edgesentry_document::{check, fill, render_html, ComplianceAlert, FilledDocument};
+use edgesentry_document::{
+    check, fill, fill_clearance, parse_clearance_facts_json, render_html, ComplianceAlert,
+    FilledDocument, PORT_CYBER_CLEARANCE_HTML,
+};
 use edgesentry_ingest::jsonl::{JsonlReader, JsonlWriter};
 use edgesentry_parse::DocumentEntity;
 
@@ -43,6 +46,15 @@ pub enum DocumentCommand {
         #[arg(long)]
         out: PathBuf,
     },
+    /// Render port cyber clearance HTML from indago `*_facts.json` (Cap Vista W5).
+    RenderClearance {
+        #[arg(long)]
+        facts: PathBuf,
+        #[arg(long, default_value = "https://verify.edgesentry.io/clearance/poc")]
+        verify_url: String,
+        #[arg(long)]
+        out: PathBuf,
+    },
 }
 
 pub fn run(cmd: DocumentCommand) -> Result<(), Box<dyn std::error::Error>> {
@@ -55,6 +67,9 @@ pub fn run(cmd: DocumentCommand) -> Result<(), Box<dyn std::error::Error>> {
         }
         DocumentCommand::Gen { input, template, out } => {
             run_gen(&input, &template, &out)
+        }
+        DocumentCommand::RenderClearance { facts, verify_url, out } => {
+            run_render_clearance(&facts, &verify_url, &out)
         }
     }
 }
@@ -151,13 +166,38 @@ fn run_gen(
         "fal-form-1" => FAL_FORM_1,
         "fal-form-5" => FAL_FORM_5,
         "sg-port-entry" => SG_PORT_ENTRY,
+        "port-cyber-clearance" => PORT_CYBER_CLEARANCE_HTML,
         other => {
-            return Err(format!("unknown template '{}'; choices: fal-form-1, fal-form-5, sg-port-entry", other).into());
+            return Err(format!(
+                "unknown template '{}'; choices: fal-form-1, fal-form-5, sg-port-entry, port-cyber-clearance",
+                other
+            )
+            .into());
         }
     };
 
     let rendered = render_html(&doc, template_html);
     fs::write(out, rendered)?;
     eprintln!("document gen: rendered '{}' → {}", template, out.display());
+    Ok(())
+}
+
+fn run_render_clearance(
+    facts_path: &PathBuf,
+    verify_url: &str,
+    out: &PathBuf,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let content = fs::read_to_string(facts_path)?;
+    let facts = parse_clearance_facts_json(&content)
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let doc = fill_clearance(&facts, verify_url);
+    let rendered = render_html(&doc, PORT_CYBER_CLEARANCE_HTML);
+    fs::write(out, rendered)?;
+    eprintln!(
+        "document render-clearance: {} → {} ({})",
+        facts_path.display(),
+        out.display(),
+        doc.fields.get("OUTCOME").map(|f| f.value.as_str()).unwrap_or("?")
+    );
     Ok(())
 }

--- a/crates/eds/tests/cli_integration.rs
+++ b/crates/eds/tests/cli_integration.rs
@@ -1292,3 +1292,64 @@ fn run_sign_verify_clearance(manifest_path: &PathBuf) {
     assert!(verify.status.success(), "verify-clearance: {}", stderr(&verify));
     assert!(stdout(&verify).contains("VERIFIED"));
 }
+
+// ── port cyber clearance document (W5) ────────────────────────────────────────
+
+fn clearance_facts_fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../edgesentry-document/fixtures/clearance")
+        .join(name)
+}
+
+#[test]
+fn render_clearance_hold_writes_html() {
+    let facts = clearance_facts_fixture("vessel-hold_facts.json");
+    assert!(facts.is_file(), "missing fixture: {}", facts.display());
+
+    let out = TmpFile::new("clearance_hold.html");
+    let render = eds()
+        .args(["document", "render-clearance", "--facts"])
+        .arg(&facts)
+        .args([
+            "--verify-url",
+            "https://verify.example/clearance/hold-demo",
+            "--out",
+        ])
+        .arg(out.path())
+        .output()
+        .expect("eds document render-clearance");
+
+    assert!(render.status.success(), "render-clearance: {}", stderr(&render));
+    assert!(
+        stderr(&render).contains("HOLD"),
+        "stderr should report HOLD outcome: {}",
+        stderr(&render)
+    );
+
+    let html = fs::read_to_string(out.path()).expect("read html");
+    assert!(html.contains("HOLD"));
+    assert!(html.contains("vessel-hold"));
+    assert!(html.contains("SG-CC-001"));
+    assert!(html.contains("https://verify.example/clearance/hold-demo"));
+    assert!(!html.contains("{{OUTCOME}}"));
+}
+
+#[test]
+fn render_clearance_pass_writes_html() {
+    let facts = clearance_facts_fixture("vessel-clean_facts.json");
+    let out = TmpFile::new("clearance_pass.html");
+
+    let render = eds()
+        .args(["document", "render-clearance", "--facts"])
+        .arg(&facts)
+        .args(["--verify-url", "https://verify.example/clearance/pass-demo", "--out"])
+        .arg(out.path())
+        .output()
+        .expect("eds document render-clearance");
+
+    assert!(render.status.success(), "render-clearance: {}", stderr(&render));
+    let html = fs::read_to_string(out.path()).expect("read html");
+    assert!(html.contains("PASS"));
+    assert!(html.contains("vessel-clean"));
+    assert!(!html.contains("SG-CC-001"));
+}


### PR DESCRIPTION
## Summary
- `fill_clearance` + `port-cyber-clearance.html` certificate (hold/pass, rules, paths, decision hash, verify URL, disclaimer).
- `eds document render-clearance --facts ... --verify-url ... --out ...`
- WASM: `fill_clearance` + `render_html("port-cyber-clearance")`.

## Related
- documaris W5: (paired PR)
- indago W3 facts.json

## Test plan
- [x] `cargo test -p edgesentry-document clearance`
- [x] `cargo build -p eds` + manual render-clearance


Made with [Cursor](https://cursor.com)