### PR TITLE
feat(document): G11/G12 audit evidence on clearance certificate (#157)

### DIFF
--- a/crates/edgesentry-audit/fixtures/clearance/vessel-hold_evaluation_manifest.json
+++ b/crates/edgesentry-audit/fixtures/clearance/vessel-hold_evaluation_manifest.json
@@ -3,12 +3,28 @@
   "port_call_id": "port-call-demo-sgsin",
   "rule_pack_id": "sg-cyber-clearance-v0",
   "rule_pack_version": "0.1.0",
-  "rule_pack_sha256": "0000000000000000000000000000000000000000000000000000000000000001",
-  "cve_snapshot_sha256": "0000000000000000000000000000000000000000000000000000000000000002",
-  "sbom_sha256": "0000000000000000000000000000000000000000000000000000000000000003",
+  "rule_pack_sha256": "40ff22cc50b794a7ebd17bb2f046cdb4da87c33bbde2a4ff9333a49f253267eb",
+  "bom_baseline_ref": {
+    "asset_map_path": "/Users/yoheionishi/work/edgesentry/indago/fixtures/asset_map.yaml",
+    "asset_map_sha256": "94627670cc4cb7fb37e030d76cc7504a35cc57b7e022f3fa479853476e4a57bf",
+    "sbom_path": "/Users/yoheionishi/work/edgesentry/indago/fixtures/sbom/vessel-hold.json",
+    "sbom_sha256": "ad9e87da1c02487a746f5c086fb2d315719cbc48e2aa3bb5ed60c3e27ab27f06"
+  },
+  "cve_snapshot_ref": {
+    "cve_snapshot_path": "/Users/yoheionishi/work/edgesentry/indago/fixtures/cve/snapshot-2026-05-26.json",
+    "cve_snapshot_sha256": "490d61991f404f6004d94657a81a0ce8b24724eade8e5ddf532d3bcb8c9cbe43"
+  },
+  "cve_snapshot_sha256": "490d61991f404f6004d94657a81a0ce8b24724eade8e5ddf532d3bcb8c9cbe43",
+  "sbom_sha256": "ad9e87da1c02487a746f5c086fb2d315719cbc48e2aa3bb5ed60c3e27ab27f06",
   "outcome": "hold",
-  "rules_fired": ["SG-CC-001", "SG-CC-002", "SG-CC-007"],
+  "rules_fired": [
+    "SG-CC-001",
+    "SG-CC-002",
+    "SG-CC-007"
+  ],
   "graph_node_count": 6,
-  "graph_edge_count": 5,
-  "decision_hash": "cf645aac3a633b4308b9ca3c267ab811c66f1a2563cd04f02daca08b2b1ec867"
+  "graph_edge_count": 6,
+  "impacted_path_count": 1,
+  "integrated_snapshot_fingerprint": "e4a3bb87687d7686c16a26c785714660960abc9d9849d278919d9c0992c89ae5",
+  "decision_hash": "04398d601ec92d5e5ee92046b4a0099acb82e3704685d66e74277b21373e4a78"
 }

--- a/crates/edgesentry-audit/fixtures/clearance/vessel-hold_evaluation_manifest.json
+++ b/crates/edgesentry-audit/fixtures/clearance/vessel-hold_evaluation_manifest.json
@@ -5,13 +5,13 @@
   "rule_pack_version": "0.1.0",
   "rule_pack_sha256": "40ff22cc50b794a7ebd17bb2f046cdb4da87c33bbde2a4ff9333a49f253267eb",
   "bom_baseline_ref": {
-    "asset_map_path": "/Users/yoheionishi/work/edgesentry/indago/fixtures/asset_map.yaml",
+    "asset_map_path": "indago/fixtures/asset_map.yaml",
     "asset_map_sha256": "94627670cc4cb7fb37e030d76cc7504a35cc57b7e022f3fa479853476e4a57bf",
-    "sbom_path": "/Users/yoheionishi/work/edgesentry/indago/fixtures/sbom/vessel-hold.json",
+    "sbom_path": "indago/fixtures/sbom/vessel-hold.json",
     "sbom_sha256": "ad9e87da1c02487a746f5c086fb2d315719cbc48e2aa3bb5ed60c3e27ab27f06"
   },
   "cve_snapshot_ref": {
-    "cve_snapshot_path": "/Users/yoheionishi/work/edgesentry/indago/fixtures/cve/snapshot-2026-05-26.json",
+    "cve_snapshot_path": "indago/fixtures/cve/snapshot-2026-05-26.json",
     "cve_snapshot_sha256": "490d61991f404f6004d94657a81a0ce8b24724eade8e5ddf532d3bcb8c9cbe43"
   },
   "cve_snapshot_sha256": "490d61991f404f6004d94657a81a0ce8b24724eade8e5ddf532d3bcb8c9cbe43",

--- a/crates/edgesentry-document/fixtures/clearance/vessel-clean_facts.json
+++ b/crates/edgesentry-document/fixtures/clearance/vessel-clean_facts.json
@@ -2,7 +2,19 @@
   "vessel_key": "vessel-clean",
   "port_call_id": "port-call-demo-sgsin",
   "outcome": "pass",
-  "decision_hash": "23f3c166a82b4d614ebccea7b26ec1aeaaa96bb854b487fbc37093cf4de31889",
+  "decision_hash": "e4c5c861d376c14ad8f25e076c2e7139bbe882a9eeb00b71fc4b6c3b86e74602",
+  "bom_baseline_ref": {
+    "asset_map_path": "indago/fixtures/asset_map.yaml",
+    "asset_map_sha256": "94627670cc4cb7fb37e030d76cc7504a35cc57b7e022f3fa479853476e4a57bf",
+    "sbom_path": "indago/fixtures/sbom/vessel-clean.json",
+    "sbom_sha256": "f14957cf59ec7104d6aee7082d9f73a228f18e5540a9ae95878bdd52ebcf71c4"
+  },
+  "cve_snapshot_ref": {
+    "cve_snapshot_path": "indago/fixtures/cve/snapshot-2026-05-26.json",
+    "cve_snapshot_sha256": "490d61991f404f6004d94657a81a0ce8b24724eade8e5ddf532d3bcb8c9cbe43"
+  },
+  "integrated_snapshot_fingerprint": "9c779e305b5614416cff473757dc9c572510b80ec3f3b8f36ad16a5a5216beff",
+  "impacted_paths": [],
   "rules_fired": [],
   "paths": [],
   "cve_ids": [],

--- a/crates/edgesentry-document/fixtures/clearance/vessel-hold_facts.json
+++ b/crates/edgesentry-document/fixtures/clearance/vessel-hold_facts.json
@@ -4,13 +4,13 @@
   "outcome": "hold",
   "decision_hash": "04398d601ec92d5e5ee92046b4a0099acb82e3704685d66e74277b21373e4a78",
   "bom_baseline_ref": {
-    "asset_map_path": "/Users/yoheionishi/work/edgesentry/indago/fixtures/asset_map.yaml",
+    "asset_map_path": "indago/fixtures/asset_map.yaml",
     "asset_map_sha256": "94627670cc4cb7fb37e030d76cc7504a35cc57b7e022f3fa479853476e4a57bf",
-    "sbom_path": "/Users/yoheionishi/work/edgesentry/indago/fixtures/sbom/vessel-hold.json",
+    "sbom_path": "indago/fixtures/sbom/vessel-hold.json",
     "sbom_sha256": "ad9e87da1c02487a746f5c086fb2d315719cbc48e2aa3bb5ed60c3e27ab27f06"
   },
   "cve_snapshot_ref": {
-    "cve_snapshot_path": "/Users/yoheionishi/work/edgesentry/indago/fixtures/cve/snapshot-2026-05-26.json",
+    "cve_snapshot_path": "indago/fixtures/cve/snapshot-2026-05-26.json",
     "cve_snapshot_sha256": "490d61991f404f6004d94657a81a0ce8b24724eade8e5ddf532d3bcb8c9cbe43"
   },
   "integrated_snapshot_fingerprint": "e4a3bb87687d7686c16a26c785714660960abc9d9849d278919d9c0992c89ae5",

--- a/crates/edgesentry-document/fixtures/clearance/vessel-hold_facts.json
+++ b/crates/edgesentry-document/fixtures/clearance/vessel-hold_facts.json
@@ -2,7 +2,38 @@
   "vessel_key": "vessel-hold",
   "port_call_id": "port-call-demo-sgsin",
   "outcome": "hold",
-  "decision_hash": "cf645aac3a633b4308b9ca3c267ab811c66f1a2563cd04f02daca08b2b1ec867",
+  "decision_hash": "04398d601ec92d5e5ee92046b4a0099acb82e3704685d66e74277b21373e4a78",
+  "bom_baseline_ref": {
+    "asset_map_path": "/Users/yoheionishi/work/edgesentry/indago/fixtures/asset_map.yaml",
+    "asset_map_sha256": "94627670cc4cb7fb37e030d76cc7504a35cc57b7e022f3fa479853476e4a57bf",
+    "sbom_path": "/Users/yoheionishi/work/edgesentry/indago/fixtures/sbom/vessel-hold.json",
+    "sbom_sha256": "ad9e87da1c02487a746f5c086fb2d315719cbc48e2aa3bb5ed60c3e27ab27f06"
+  },
+  "cve_snapshot_ref": {
+    "cve_snapshot_path": "/Users/yoheionishi/work/edgesentry/indago/fixtures/cve/snapshot-2026-05-26.json",
+    "cve_snapshot_sha256": "490d61991f404f6004d94657a81a0ce8b24724eade8e5ddf532d3bcb8c9cbe43"
+  },
+  "integrated_snapshot_fingerprint": "e4a3bb87687d7686c16a26c785714660960abc9d9849d278919d9c0992c89ae5",
+  "impacted_paths": [
+    {
+      "vessel_id": "vessel:vessel-hold",
+      "asset_id": "asset:vessel-hold:ecdis-01",
+      "asset_name": null,
+      "firmware_id": "firmware:vessel-hold:ecdis-fw-2023.4",
+      "component_id": "component:vessel-hold:27620e88ddac",
+      "component_name": "log4j-core",
+      "component_purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1",
+      "cve_id": "cve:CVE-2021-44228",
+      "cve_osv_id": "GHSA-jfhr-c2vg-8q4j",
+      "cvss_score": 10.0,
+      "path_nodes": [
+        "asset:vessel-hold:ecdis-01",
+        "firmware:vessel-hold:ecdis-fw-2023.4",
+        "component:vessel-hold:27620e88ddac",
+        "cve:CVE-2021-44228"
+      ]
+    }
+  ],
   "rules_fired": [
     {
       "id": "SG-CC-001",

--- a/crates/edgesentry-document/src/clearance.rs
+++ b/crates/edgesentry-document/src/clearance.rs
@@ -20,6 +20,34 @@ pub struct ClearanceFacts {
     #[serde(default)]
     pub cve_ids: Vec<String>,
     pub disclaimer: String,
+    #[serde(default)]
+    pub bom_baseline_ref: Option<serde_json::Value>,
+    #[serde(default)]
+    pub cve_snapshot_ref: Option<serde_json::Value>,
+    #[serde(default)]
+    pub integrated_snapshot_fingerprint: Option<String>,
+    #[serde(default)]
+    pub impacted_paths: Vec<ImpactedPath>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct ImpactedPath {
+    #[serde(default)]
+    pub asset_name: Option<String>,
+    #[serde(default)]
+    pub asset_id: Option<String>,
+    #[serde(default)]
+    pub component_name: Option<String>,
+    #[serde(default)]
+    pub component_purl: Option<String>,
+    #[serde(default)]
+    pub cve_id: Option<String>,
+    #[serde(default)]
+    pub cve_osv_id: Option<String>,
+    #[serde(default)]
+    pub cvss_score: Option<f64>,
+    #[serde(default)]
+    pub path_nodes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -79,6 +107,67 @@ fn rules_table_rows(rules: &[ClearanceRuleHit]) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn audit_evidence_html(facts: &ClearanceFacts) -> String {
+    let bom = facts
+        .bom_baseline_ref
+        .as_ref()
+        .and_then(|v| v.as_object())
+        .cloned()
+        .unwrap_or_default();
+    let cve = facts
+        .cve_snapshot_ref
+        .as_ref()
+        .and_then(|v| v.as_object())
+        .cloned()
+        .unwrap_or_default();
+
+    let bom_sbom_sha = bom
+        .get("sbom_sha256")
+        .and_then(|v| v.as_str())
+        .unwrap_or("—");
+    let cve_sha = cve
+        .get("cve_snapshot_sha256")
+        .and_then(|v| v.as_str())
+        .unwrap_or("—");
+    let fingerprint = facts
+        .integrated_snapshot_fingerprint
+        .as_deref()
+        .unwrap_or("—");
+
+    let mut rows = String::from(
+        "<table><thead><tr><th>Asset</th><th>Component</th><th>CVE</th><th>CVSS</th></tr></thead><tbody>",
+    );
+    if facts.impacted_paths.is_empty() {
+        rows.push_str("<tr><td colspan=\"4\" class=\"muted\">No impacted paths on evaluation</td></tr>");
+    } else {
+        for p in &facts.impacted_paths {
+            rows.push_str(&format!(
+                "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+                escape_html(p.asset_name.as_deref().unwrap_or("—")),
+                escape_html(
+                    p.component_purl
+                        .as_deref()
+                        .or(p.component_name.as_deref())
+                        .unwrap_or("—"),
+                ),
+                escape_html(p.cve_osv_id.as_deref().or(p.cve_id.as_deref()).unwrap_or("—")),
+                p.cvss_score
+                    .map(|s| format!("{s:.1}"))
+                    .unwrap_or_else(|| "—".to_string()),
+            ));
+        }
+    }
+    rows.push_str("</tbody></table>");
+
+    format!(
+        "<p><strong>Frozen BOM baseline</strong> (SBOM SHA-256): <code>{bom_sbom_sha}</code></p>\
+         <p><strong>CVE snapshot at audit time</strong> (SHA-256): <code>{cve_sha}</code></p>\
+         <p><strong>Integrated BOM×CVE fingerprint</strong> (G11): <code>{fingerprint}</code></p>\
+         <p class=\"muted\">Latest CVE intelligence applied to pinned SBOM baseline — G12 impacted paths:</p>\
+         {rows}"
+    )
 }
 
 fn paths_table_rows(paths: &[ClearancePath]) -> String {
@@ -150,6 +239,10 @@ pub fn fill_clearance(facts: &ClearanceFacts, verify_url: &str) -> FilledDocumen
     fields.insert("RULES_TABLE_ROWS".to_string(), direct(rules_table_rows(&facts.rules_fired)));
     fields.insert("PATHS_TABLE_ROWS".to_string(), direct(paths_table_rows(&facts.paths)));
     fields.insert(
+        "AUDIT_EVIDENCE_HTML".to_string(),
+        direct(audit_evidence_html(facts)),
+    );
+    fields.insert(
         "RULES_COUNT".to_string(),
         direct(facts.rules_fired.len().to_string()),
     );
@@ -202,6 +295,9 @@ mod tests {
         assert!(html.contains("vessel-hold"));
         assert!(html.contains("https://verify.example/clearance/abc123"));
         assert!(html.contains("SG-CC-001"));
+        assert!(html.contains("Audit evidence"));
+        assert!(html.contains("Integrated BOM"));
         assert!(!html.contains("{{OUTCOME}}"));
+        assert!(!html.contains("{{AUDIT_EVIDENCE_HTML}}"));
     }
 }

--- a/crates/edgesentry-document/src/clearance.rs
+++ b/crates/edgesentry-document/src/clearance.rs
@@ -287,6 +287,44 @@ mod tests {
     }
 
     #[test]
+    fn hold_facts_parse_audit_evidence_fields() {
+        let facts = parse_clearance_facts_json(HOLD_FACTS).unwrap();
+        assert!(facts.bom_baseline_ref.is_some());
+        assert!(facts.cve_snapshot_ref.is_some());
+        assert_eq!(
+            facts.integrated_snapshot_fingerprint.as_deref(),
+            Some("e4a3bb87687d7686c16a26c785714660960abc9d9849d278919d9c0992c89ae5"),
+        );
+        assert_eq!(facts.impacted_paths.len(), 1);
+        assert_eq!(
+            facts.impacted_paths[0].component_purl.as_deref(),
+            Some("pkg:maven/org.apache.logging.log4j/log4j-core@2.14.1"),
+        );
+    }
+
+    #[test]
+    fn audit_evidence_html_renders_g11_g12_hashes_and_impacted_path() {
+        let facts = parse_clearance_facts_json(HOLD_FACTS).unwrap();
+        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo");
+        let section = doc.fields.get("AUDIT_EVIDENCE_HTML").expect("field").value.as_str();
+        assert!(section.contains("ad9e87da1c02487a746f5c086fb2d315719cbc48e2aa3bb5ed60c3e27ab27f06"));
+        assert!(section.contains("490d61991f404f6004d94657a81a0ce8b24724eade8e5ddf532d3bcb8c9cbe43"));
+        assert!(section.contains("e4a3bb87687d7686c16a26c785714660960abc9d9849d278919d9c0992c89ae5"));
+        assert!(section.contains("log4j-core"));
+        assert!(section.contains("GHSA-jfhr-c2vg-8q4j"));
+        assert!(section.contains("10.0"));
+    }
+
+    #[test]
+    fn audit_evidence_html_pass_vessel_shows_no_impacted_paths() {
+        let facts = parse_clearance_facts_json(CLEAN_FACTS).unwrap();
+        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo");
+        let section = doc.fields.get("AUDIT_EVIDENCE_HTML").expect("field").value.as_str();
+        assert!(section.contains("No impacted paths on evaluation"));
+        assert!(facts.impacted_paths.is_empty());
+    }
+
+    #[test]
     fn render_clearance_html_contains_outcome_and_verify() {
         let facts = parse_clearance_facts_json(HOLD_FACTS).unwrap();
         let doc = fill_clearance(&facts, "https://verify.example/clearance/abc123");
@@ -295,8 +333,9 @@ mod tests {
         assert!(html.contains("vessel-hold"));
         assert!(html.contains("https://verify.example/clearance/abc123"));
         assert!(html.contains("SG-CC-001"));
-        assert!(html.contains("Audit evidence"));
-        assert!(html.contains("Integrated BOM"));
+        assert!(html.contains("Audit evidence (G11 / G12)"));
+        assert!(html.contains("Frozen BOM baseline"));
+        assert!(html.contains("ad9e87da1c02487a746f5c086fb2d315719cbc48e2aa3bb5ed60c3e27ab27f06"));
         assert!(!html.contains("{{OUTCOME}}"));
         assert!(!html.contains("{{AUDIT_EVIDENCE_HTML}}"));
     }

--- a/crates/edgesentry-document/templates/port-cyber-clearance.html
+++ b/crates/edgesentry-document/templates/port-cyber-clearance.html
@@ -116,11 +116,14 @@
   </tbody>
 </table>
 
-<div class="section-title">4. Decision integrity</div>
+<div class="section-title">4. Audit evidence (G11 / G12)</div>
+{{AUDIT_EVIDENCE_HTML}}
+
+<div class="section-title">5. Decision integrity</div>
 <p class="muted">Canonical evaluation hash (indago manifest, excludes this field):</p>
 <div class="hash-box">{{DECISION_HASH}}</div>
 
-<div class="section-title">5. Independent verification</div>
+<div class="section-title">6. Independent verification</div>
 <div class="verify-box">
   Third parties can verify the signed audit chain and manifest match using <code>eds audit verify-clearance</code>.
   Portal placeholder (W6): <a href="{{VERIFY_URL}}">{{VERIFY_URL}}</a>


### PR DESCRIPTION
## Summary
- Render **§4 Audit evidence (G11/G12)** on port-cyber-clearance HTML
- Extend `ClearanceFacts` for `bom_baseline_ref`, `cve_snapshot_ref`, `impacted_paths`
- Refresh `vessel-hold_facts.json` + evaluation manifest fixture

## Test plan
- [x] `cargo test -p edgesentry-document -- clearance`

## Linked issues
- Related: https://github.com/edgesentry/edgesentry-commercial/issues/157

Made with [Cursor](https://cursor.com)