### PR TITLE
feat(document): D5 operator explanation on clearance HTML

### DIFF
--- a/crates/edgesentry-document/src/clearance.rs
+++ b/crates/edgesentry-document/src/clearance.rs
@@ -188,6 +188,28 @@ fn paths_table_rows(paths: &[ClearancePath]) -> String {
         .join("\n")
 }
 
+fn operator_explanation_section(text: Option<&str>) -> String {
+    let Some(raw) = text.map(str::trim).filter(|s| !s.is_empty()) else {
+        return String::new();
+    };
+    let body = raw
+        .split("\n\n")
+        .map(str::trim)
+        .filter(|p| !p.is_empty())
+        .map(|p| format!("<p>{}</p>", escape_html(p).replace('\n', "<br/>")))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "<div class=\"section-title\">1a. Operator explanation (facts-derived, non-authoritative)</div>\
+         <div class=\"ai-narrative\">\
+         <p class=\"muted\"><strong>AI automates explanation, not compliance judgment.</strong> \
+         This section is synthesized from evaluation facts for operator context only. \
+         It does not change the deterministic outcome or <code>decision_hash</code>.</p>\
+         {body}\
+         </div>"
+    )
+}
+
 fn summary_paragraph(facts: &ClearanceFacts) -> String {
     let outcome_upper = facts.outcome.to_uppercase();
     if facts.outcome == "hold" {
@@ -211,7 +233,11 @@ fn summary_paragraph(facts: &ClearanceFacts) -> String {
 }
 
 /// Map indago facts + verify URL into a `FilledDocument` for `port-cyber-clearance.html`.
-pub fn fill_clearance(facts: &ClearanceFacts, verify_url: &str) -> FilledDocument {
+pub fn fill_clearance(
+    facts: &ClearanceFacts,
+    verify_url: &str,
+    operator_explanation: Option<&str>,
+) -> FilledDocument {
     let outcome_upper = facts.outcome.to_uppercase();
     let outcome_class = if facts.outcome == "hold" {
         "outcome-hold"
@@ -236,6 +262,10 @@ pub fn fill_clearance(facts: &ClearanceFacts, verify_url: &str) -> FilledDocumen
     fields.insert("CVE_IDS".to_string(), direct(cve_line));
     fields.insert("DISCLAIMER".to_string(), direct(&facts.disclaimer));
     fields.insert("SUMMARY_HTML".to_string(), direct(summary_paragraph(facts)));
+    fields.insert(
+        "OPERATOR_EXPLANATION_SECTION".to_string(),
+        direct(operator_explanation_section(operator_explanation)),
+    );
     fields.insert("RULES_TABLE_ROWS".to_string(), direct(rules_table_rows(&facts.rules_fired)));
     fields.insert("PATHS_TABLE_ROWS".to_string(), direct(paths_table_rows(&facts.paths)));
     fields.insert(
@@ -272,7 +302,7 @@ mod tests {
     #[test]
     fn fill_clearance_hold_marks_review_required() {
         let facts = parse_clearance_facts_json(HOLD_FACTS).unwrap();
-        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo");
+        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo", None);
         assert!(doc.review_required);
         assert_eq!(doc.template, TEMPLATE_ID);
         assert_eq!(doc.fields.get("OUTCOME").unwrap().value, "HOLD");
@@ -281,7 +311,7 @@ mod tests {
     #[test]
     fn fill_clearance_pass_no_review() {
         let facts = parse_clearance_facts_json(CLEAN_FACTS).unwrap();
-        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo");
+        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo", None);
         assert!(!doc.review_required);
         assert_eq!(doc.fields.get("OUTCOME").unwrap().value, "PASS");
     }
@@ -305,7 +335,7 @@ mod tests {
     #[test]
     fn audit_evidence_html_renders_g11_g12_hashes_and_impacted_path() {
         let facts = parse_clearance_facts_json(HOLD_FACTS).unwrap();
-        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo");
+        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo", None);
         let section = doc.fields.get("AUDIT_EVIDENCE_HTML").expect("field").value.as_str();
         assert!(section.contains("ad9e87da1c02487a746f5c086fb2d315719cbc48e2aa3bb5ed60c3e27ab27f06"));
         assert!(section.contains("490d61991f404f6004d94657a81a0ce8b24724eade8e5ddf532d3bcb8c9cbe43"));
@@ -318,7 +348,7 @@ mod tests {
     #[test]
     fn audit_evidence_html_pass_vessel_shows_no_impacted_paths() {
         let facts = parse_clearance_facts_json(CLEAN_FACTS).unwrap();
-        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo");
+        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo", None);
         let section = doc.fields.get("AUDIT_EVIDENCE_HTML").expect("field").value.as_str();
         assert!(section.contains("No impacted paths on evaluation"));
         assert!(facts.impacted_paths.is_empty());
@@ -327,7 +357,7 @@ mod tests {
     #[test]
     fn render_clearance_html_contains_outcome_and_verify() {
         let facts = parse_clearance_facts_json(HOLD_FACTS).unwrap();
-        let doc = fill_clearance(&facts, "https://verify.example/clearance/abc123");
+        let doc = fill_clearance(&facts, "https://verify.example/clearance/abc123", None);
         let html = render_html(&doc, TEMPLATE_HTML);
         assert!(html.contains("HOLD"));
         assert!(html.contains("vessel-hold"));
@@ -338,5 +368,29 @@ mod tests {
         assert!(html.contains("ad9e87da1c02487a746f5c086fb2d315719cbc48e2aa3bb5ed60c3e27ab27f06"));
         assert!(!html.contains("{{OUTCOME}}"));
         assert!(!html.contains("{{AUDIT_EVIDENCE_HTML}}"));
+    }
+
+    #[test]
+    fn render_clearance_html_includes_operator_explanation_when_provided() {
+        let facts = parse_clearance_facts_json(HOLD_FACTS).unwrap();
+        let narrative = "Operator context for vessel-hold. The rule engine recorded clearance outcome HOLD.";
+        let doc = fill_clearance(&facts, "https://verify.example/clearance/abc123", Some(narrative));
+        let html = render_html(&doc, TEMPLATE_HTML);
+        assert!(html.contains("Operator explanation (facts-derived, non-authoritative)"));
+        assert!(html.contains("AI automates explanation, not compliance judgment"));
+        assert!(html.contains("vessel-hold"));
+    }
+
+    #[test]
+    fn operator_explanation_section_empty_when_none() {
+        let facts = parse_clearance_facts_json(HOLD_FACTS).unwrap();
+        let doc = fill_clearance(&facts, "https://verify.example/clearance/demo", None);
+        let section = doc
+            .fields
+            .get("OPERATOR_EXPLANATION_SECTION")
+            .expect("field")
+            .value
+            .as_str();
+        assert!(section.is_empty());
     }
 }

--- a/crates/edgesentry-document/templates/port-cyber-clearance.html
+++ b/crates/edgesentry-document/templates/port-cyber-clearance.html
@@ -75,6 +75,15 @@
     color: #64748b;
   }
   .footer { font-size: 8px; color: #94a3b8; margin-top: 8px; }
+  .ai-narrative {
+    background: #fffbeb;
+    border: 1px solid #fcd34d;
+    padding: 10px 12px;
+    margin-bottom: 12px;
+    font-size: 10px;
+  }
+  .ai-narrative p { margin: 0 0 8px; }
+  .ai-narrative p:last-child { margin-bottom: 0; }
 </style>
 </head>
 <body>
@@ -95,6 +104,8 @@
 
 <div class="section-title">1. Executive summary</div>
 <p class="summary">{{SUMMARY_HTML}}</p>
+
+{{OPERATOR_EXPLANATION_SECTION}}
 
 <div class="section-title">2. Rules fired</div>
 <table>

--- a/crates/edgesentry-wasm/src/lib.rs
+++ b/crates/edgesentry-wasm/src/lib.rs
@@ -82,7 +82,7 @@ pub fn fill_bca(
 pub fn fill_clearance(facts_json: &str, verify_url: &str) -> Result<String, JsError> {
     let facts = edgesentry_document::parse_clearance_facts_json(facts_json)
         .map_err(|e| JsError::new(&e))?;
-    let filled = edgesentry_document::fill_clearance(&facts, verify_url);
+    let filled = edgesentry_document::fill_clearance(&facts, verify_url, None);
     serde_json::to_string(&filled).map_err(|e| JsError::new(&e.to_string()))
 }
 

--- a/crates/eds/src/document.rs
+++ b/crates/eds/src/document.rs
@@ -200,7 +200,7 @@ fn run_render_clearance(
     let facts = parse_clearance_facts_json(&content)
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
     let operator_explanation = operator_explanation_path
-        .map(|p| fs::read_to_string(p))
+        .map(fs::read_to_string)
         .transpose()
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
     let doc = fill_clearance(

--- a/crates/eds/src/document.rs
+++ b/crates/eds/src/document.rs
@@ -47,14 +47,19 @@ pub enum DocumentCommand {
         out: PathBuf,
     },
     /// Render port cyber clearance HTML from indago `*_facts.json` (Cap Vista W5).
-    RenderClearance {
-        #[arg(long)]
-        facts: PathBuf,
-        #[arg(long, default_value = "https://verify.edgesentry.io/clearance/poc")]
-        verify_url: String,
-        #[arg(long)]
-        out: PathBuf,
-    },
+    RenderClearance(RenderClearanceArgs),
+}
+
+#[derive(Debug, clap::Args)]
+pub struct RenderClearanceArgs {
+    #[arg(long)]
+    pub facts: PathBuf,
+    #[arg(long, default_value = "https://verify.edgesentry.io/clearance/poc")]
+    pub verify_url: String,
+    #[arg(long)]
+    pub operator_explanation: Option<PathBuf>,
+    #[arg(long)]
+    pub out: PathBuf,
 }
 
 pub fn run(cmd: DocumentCommand) -> Result<(), Box<dyn std::error::Error>> {
@@ -68,9 +73,12 @@ pub fn run(cmd: DocumentCommand) -> Result<(), Box<dyn std::error::Error>> {
         DocumentCommand::Gen { input, template, out } => {
             run_gen(&input, &template, &out)
         }
-        DocumentCommand::RenderClearance { facts, verify_url, out } => {
-            run_render_clearance(&facts, &verify_url, &out)
-        }
+        DocumentCommand::RenderClearance(args) => run_render_clearance(
+            &args.facts,
+            &args.verify_url,
+            args.operator_explanation.as_ref(),
+            &args.out,
+        ),
     }
 }
 
@@ -185,12 +193,21 @@ fn run_gen(
 fn run_render_clearance(
     facts_path: &PathBuf,
     verify_url: &str,
+    operator_explanation_path: Option<&PathBuf>,
     out: &PathBuf,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let content = fs::read_to_string(facts_path)?;
     let facts = parse_clearance_facts_json(&content)
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-    let doc = fill_clearance(&facts, verify_url);
+    let operator_explanation = operator_explanation_path
+        .map(|p| fs::read_to_string(p))
+        .transpose()
+        .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    let doc = fill_clearance(
+        &facts,
+        verify_url,
+        operator_explanation.as_deref(),
+    );
     let rendered = render_html(&doc, PORT_CYBER_CLEARANCE_HTML);
     fs::write(out, rendered)?;
     eprintln!(

--- a/crates/eds/tests/cli_integration.rs
+++ b/crates/eds/tests/cli_integration.rs
@@ -1335,6 +1335,41 @@ fn render_clearance_hold_writes_html() {
 }
 
 #[test]
+fn render_clearance_with_operator_explanation_writes_section() {
+    let facts = clearance_facts_fixture("vessel-hold_facts.json");
+    let explanation = TmpFile::new("operator_explanation.txt");
+    fs::write(
+        explanation.path(),
+        "Operator context for vessel-hold. The rule engine recorded clearance outcome HOLD.",
+    )
+    .expect("write explanation");
+
+    let out = TmpFile::new("clearance_hold_with_narrative.html");
+    let render = eds()
+        .args(["document", "render-clearance", "--facts"])
+        .arg(&facts)
+        .arg("--operator-explanation")
+        .arg(explanation.path())
+        .args([
+            "--verify-url",
+            "https://verify.example/clearance/hold-narrative",
+            "--out",
+        ])
+        .arg(out.path())
+        .output()
+        .expect("eds document render-clearance");
+
+    assert!(
+        render.status.success(),
+        "render-clearance with operator explanation: {}",
+        stderr(&render)
+    );
+    let html = fs::read_to_string(out.path()).expect("read html");
+    assert!(html.contains("Operator explanation (facts-derived, non-authoritative)"));
+    assert!(html.contains("AI automates explanation, not compliance judgment"));
+}
+
+#[test]
 fn render_clearance_pass_writes_html() {
     let facts = clearance_facts_fixture("vessel-clean_facts.json");
     let out = TmpFile::new("clearance_pass.html");


### PR DESCRIPTION
## Summary

- Adds `--operator-explanation` to `eds document render-clearance` for optional section **1a** (non-authoritative narrative text from indago).
- Renders escaped HTML block in `port-cyber-clearance.html`; WASM `fill_clearance` passes through `None` (unchanged default).
- Does not alter `decision_hash` or facts JSON used for integrity fields.

Refs [edgesentry-commercial#160](https://github.com/edgesentry/edgesentry-commercial/issues/160)

Companion PR: indago `run_clearance --ai-narrative` produces `*_operator_explanation.txt`.

## Test plan

- [x] `cargo test -p edgesentry-document -p eds -- render_clearance operator_explanation`
- [ ] `eds document render-clearance --facts … --operator-explanation …` (manual smoke)


Made with [Cursor](https://cursor.com)